### PR TITLE
Code review fixes: CLAUDE.md, async OpenAI, dedup, Discord limits, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,19 @@ docker run --rm \
   darkstar
 ```
 
-There are currently **no tests, no linter config, and no CI** beyond Dependabot.
+### Tests + lint
+
+```bash
+pip install -r requirements-dev.txt
+ruff check .
+pytest                       # all tests
+pytest tests/test_dedup.py   # one file
+pytest -k "shuffle"          # one test by keyword
+```
+
+Tests live in `tests/` and cover the pure helpers — `parse_quiz_response`, `validate_quiz_questions`, `shuffle_quiz_options`, the dedup chain, and the small Discord/OpenAI helpers. They import `app` directly; `tests/conftest.py` populates fake env vars so the import succeeds without contacting Discord or OpenAI. The Discord/OpenAI clients in `app.py` are constructed lazily and make no requests until called, so tests don't need to mock them.
+
+CI lives at `.github/workflows/ci.yml` and runs ruff + pytest on push to main and on every PR. Ruff config in `pyproject.toml` is intentionally conservative (`select = ["F", "E9", "W6"]`) so existing code passes without a style sweep; expand to `E/W/B/UP/I` in a follow-up.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+DarkstarAIC is a single-file Discord bot (`app.py`) that provides PDF-grounded Q&A and timed multiple-choice quizzes for the DCS Air Control Communication community. It uses the OpenAI Responses API with a `file_search` tool backed by a vector store. Deployed on Railway via Docker.
+
+## Running
+
+Three environment variables are required and the bot will crash on startup without them:
+
+- `DISCORD_TOKEN` — Discord bot token
+- `OPENAI_API_KEY` — OpenAI API key
+- `ASSISTANT_ID` — an existing OpenAI Assistant (still required even though the bot uses the Responses API; see "Assistant config bootstrap" below)
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Docker (matches Railway production):
+
+```bash
+docker build -t darkstar .
+docker run --rm \
+  -e DISCORD_TOKEN=... -e OPENAI_API_KEY=... -e ASSISTANT_ID=... \
+  darkstar
+```
+
+There are currently **no tests, no linter config, and no CI** beyond Dependabot.
+
+## Architecture
+
+### Single-file layout (`app.py`)
+
+Roughly in file order:
+
+1. **Environment + OpenAI client + logging setup** (top of file)
+2. **UI components** — `QuizAnswerButton`, `QuizQuestionView` (Discord buttons)
+3. **`check_bot_permissions`** — every slash command calls this first; produces verbose diagnostic strings when perms are missing
+4. **`initialize_assistant_config` + `ask_assistant`** — the OpenAI integration layer
+5. **Quiz pipeline** — `format_mcq`, `shuffle_quiz_options`, dedup helpers, `generate_quiz`, `auto_end_quiz`, `display_quiz_results`
+6. **Slash commands** — `/ask`, `/quiz_start`, `/quiz_answer`, `/quiz_end`, `/quiz_score`, `/info`
+7. **`on_ready` + `client.run()`**
+
+### Assistant config bootstrap
+
+The bot was migrated from the Assistants API to the Responses API (see `MIGRATION_NOTES.md`), but it still uses `oai.beta.assistants.retrieve(ASSISTANT_ID)` at startup to read the assistant's `instructions`, `model`, and `vector_store_ids`. Those are cached in the module-level `ASSISTANT_CONFIG` dict and used to build every Responses API request. **Before `on_ready` completes, `ASSISTANT_CONFIG` values are all `None`** — any code path that runs before bot startup will see empty config.
+
+### Quiz state
+
+`QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id`. Each entry holds the question list (shuffled), per-user answers, end time, duration, and initiator user ID.
+
+**This is in-memory only.** Any process restart (deploy, Railway OOM, crash) wipes all in-flight quizzes with no recovery. Only one quiz per channel at a time.
+
+`auto_end_quiz` is scheduled via `asyncio.create_task(...)` at quiz start; the task reference is **not stored**, and is not cancelled on `/quiz_end`. Long quizzes leave orphan sleep tasks alive until their timer fires.
+
+### Quiz generation pipeline
+
+`generate_quiz` is the most complex function. The flow:
+
+1. Build prompt asking for N MCQs with `q`, `options`, `answer`, `explain`, `topic`, `page` fields
+2. Call `ask_assistant` with `temperature=0.7`
+3. Strip ```` ```json ```` fences, parse JSON
+4. Validate (require `q`/`options`/`answer`/`explain` only — `topic` and `page` are **not** enforced)
+5. Run `deduplicate_questions` (see below)
+6. If under target count, regenerate up to 3 times with an "exclude these topics" prompt at `temperature=0.8`
+7. Shuffle each question's options via `shuffle_quiz_options` (re-letters the correct answer)
+
+### Deduplication
+
+Three signals in `are_questions_similar`:
+
+1. **Exact topic-tag match** — short-circuits to `True`. Combined with `extract_topic_from_question` returning `"unknown"` when the `topic` field is missing, this means **any two questions both lacking `topic` collapse to one**.
+2. Fuzzy text ratio > 85% via `difflib.SequenceMatcher`
+3. Top-5 keyword overlap > 40% (after stopword removal)
+
+If you touch this logic, also update the topic-field validation in `generate_quiz` — they're coupled.
+
+### Response parsing in `ask_assistant`
+
+Citation markers like `【4:2†source】` are stripped via regex before returning. Only `response.output[0]` is inspected for the `message` type — when `file_search` actually fires, the first output item may be a `file_search_call` and the message will be silently skipped.
+
+### Permissions
+
+`check_bot_permissions` builds a multi-line diagnostic string by walking `@everyone`, each bot role, and any member-specific overwrite. It does **not** check the `applications.commands` scope. DMs short-circuit to "ok".
+
+### Logging
+
+Four named loggers — `__main__`, `discord_bot`, `quiz`, `openai_api` — all to stdout (Railway captures stdout). Format includes `funcName:lineno`. Debug-level logs include raw user answer dicts.
+
+## Slash command sync
+
+`tree.sync()` runs on every `on_ready` and is **global** (no `guild=` arg). Global syncs are rate-limited and can take up to an hour to propagate. For dev work, register to a specific guild instead.
+
+## Deployment notes
+
+- `Dockerfile` runs as non-root `appuser` (uid 1000) and sets `MALLOC_ARENA_MAX=2` to reduce glibc fragmentation
+- `railway.json` configures `ON_FAILURE` restart with up to 10 retries — combined with in-memory quiz state, this means a flaky deploy can silently wipe active quizzes multiple times
+- `h11==0.16.0` is pinned in `requirements.txt` for a security fix; if you bump `discord.py` or `openai`, verify `h11` compatibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-DarkstarAIC is a single-file Discord bot (`app.py`) that provides PDF-grounded Q&A and timed multiple-choice quizzes for the DCS Air Control Communication community. It uses the OpenAI Responses API with a `file_search` tool backed by a vector store. Deployed on Railway via Docker.
+DarkstarAIC is a single-file Discord bot (`app.py`) that provides PDF-grounded Q&A and timed multiple-choice quizzes for the DCS Air Control Communication community. It uses the OpenAI Responses API (via `AsyncOpenAI`) with a `file_search` tool backed by a vector store. Deployed on Railway via Docker.
 
 ## Running
 
@@ -50,41 +50,53 @@ The bot was migrated from the Assistants API to the Responses API (see `MIGRATIO
 
 ### Quiz state
 
-`QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id`. Each entry holds the question list (shuffled), per-user answers, end time, duration, and initiator user ID.
+`QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id`. Each entry holds the question list (shuffled), per-user answers, end time, duration, initiator user ID, and the `auto_end_quiz` task handle.
 
 **This is in-memory only.** Any process restart (deploy, Railway OOM, crash) wipes all in-flight quizzes with no recovery. Only one quiz per channel at a time.
 
-`auto_end_quiz` is scheduled via `asyncio.create_task(...)` at quiz start; the task reference is **not stored**, and is not cancelled on `/quiz_end`. Long quizzes leave orphan sleep tasks alive until their timer fires.
+`auto_end_quiz` is scheduled via `asyncio.create_task(...)` at quiz start; the task handle is stored in `state["end_task"]` to keep it from being GC'd and so `display_quiz_results` can cancel it on manual `/quiz_end`. The cancel path skips itself when invoked from inside the auto-end task to avoid `CancelledError` on self.
 
 ### Quiz generation pipeline
 
 `generate_quiz` is the most complex function. The flow:
 
-1. Build prompt asking for N MCQs with `q`, `options`, `answer`, `explain`, `topic`, `page` fields
-2. Call `ask_assistant` with `temperature=0.7`
-3. Strip ```` ```json ```` fences, parse JSON
-4. Validate (require `q`/`options`/`answer`/`explain` only — `topic` and `page` are **not** enforced)
+1. Build prompt asking for N MCQs covering distinct topics
+2. Call `ask_assistant` with `temperature=0.7` and `response_format=QUIZ_RESPONSE_FORMAT` (strict json_schema requiring `q`, `options`, `answer` ∈ {A,B,C,D}, `explain`, `page`, `topic`)
+3. `parse_quiz_response` extracts the `questions` array (with permissive ```` ```json ```` fence stripping as a fallback)
+4. `validate_quiz_questions` filters to items with exactly 4 options and a valid answer letter
 5. Run `deduplicate_questions` (see below)
-6. If under target count, regenerate up to 3 times with an "exclude these topics" prompt at `temperature=0.8`
-7. Shuffle each question's options via `shuffle_quiz_options` (re-letters the correct answer)
+6. If under target count, regenerate up to 3 times at `temperature=0.8` with an "exclude these topics" prompt (also schema-constrained)
+7. Shuffle each question's options via `shuffle_quiz_options` (re-letters the correct answer, preserves every other field)
 
 ### Deduplication
 
 Three signals in `are_questions_similar`:
 
-1. **Exact topic-tag match** — short-circuits to `True`. Combined with `extract_topic_from_question` returning `"unknown"` when the `topic` field is missing, this means **any two questions both lacking `topic` collapse to one**.
+1. **Exact topic-tag match** — short-circuits to `True`. Because `QUIZ_RESPONSE_FORMAT` makes `topic` required, this no longer collapses multiple "unknown" questions into one (the previous behavior).
 2. Fuzzy text ratio > 85% via `difflib.SequenceMatcher`
 3. Top-5 keyword overlap > 40% (after stopword removal)
 
-If you touch this logic, also update the topic-field validation in `generate_quiz` — they're coupled.
+If you touch the schema and remove the `topic` requirement, restore the validation guard before relying on the dedup logic — they're coupled.
 
 ### Response parsing in `ask_assistant`
 
-Citation markers like `【4:2†source】` are stripped via regex before returning. Only `response.output[0]` is inspected for the `message` type — when `file_search` actually fires, the first output item may be a `file_search_call` and the message will be silently skipped.
+Citation markers like `【4:2†source】` are stripped via regex before returning. The code iterates every item in `response.output` looking for `message` types and skips tool-call items (e.g. `file_search_call`), so a tool-call landing before the message no longer swallows the response.
+
+`ask_assistant` also accepts a `response_format` dict that gets wired into the Responses-API `text.format` slot for structured outputs. Pass `model_supports_temperature(model)` is consulted before sending `temperature` — reasoning models (o1/o3/o4) and the gpt-5 family reject it.
 
 ### Permissions
 
-`check_bot_permissions` builds a multi-line diagnostic string by walking `@everyone`, each bot role, and any member-specific overwrite. It does **not** check the `applications.commands` scope. DMs short-circuit to "ok".
+`check_bot_permissions` builds a multi-line diagnostic string by walking `@everyone`, each bot role, and any member-specific overwrite. It checks `send_messages`, `embed_links`, `read_message_history`, `view_channel`, and `use_application_commands`. The final message is truncated at 1900 chars to stay inside Discord's 2000-char interaction limit. DMs short-circuit to "ok".
+
+### Discord limit helpers
+
+Three small helpers near `format_mcq` exist to keep Discord output inside platform limits:
+
+- `format_time_remaining(end_time)` — `(minutes, seconds)` bounded at 0, used everywhere the bot displays a countdown
+- `truncate_for_discord(text, limit=2000)` — closes any open triple-backtick fence before truncating so markdown stays well-formed
+- `chunk_mentions(user_ids, base_name)` — packs `<@id>` strings into 1024-char embed-field-value chunks; paginates field name as `"<base> (1/2)"` etc. when needed
+
+If you display user mentions or LLM-generated prose, route through these rather than building strings inline.
 
 ### Logging
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,15 @@ The bot will generate unique questions, track your progress, and provide detaile
 - **`/quiz_start [topic] [questions] [duration]`** - Start a quiz session
   - `topic` (optional): Focus on specific topics
   - `questions` (optional): Number of questions (1-10, default: 5)
-  - `duration` (optional): Quiz duration in minutes (1-480, default: 15)
+  - `duration` (optional): Quiz duration in minutes (1-60, default: 15)
   ```
   /quiz_start topic:radio-procedures questions:8 duration:10
+  ```
+
+- **`/quiz_answer <question_number> <choice>`** - Submit an answer by question number
+  (alternative to clicking the buttons under each question)
+  ```
+  /quiz_answer question_number:3 choice:B
   ```
 
 - **`/quiz_score`** - View your current quiz progress
@@ -58,7 +64,8 @@ The bot will generate unique questions, track your progress, and provide detaile
   /quiz_score
   ```
 
-- **`/quiz_end`** - End the current quiz and view final results
+- **`/quiz_end`** - End the current quiz and view final results.
+  Only the quiz initiator or a user with **Manage Messages** can end a running quiz.
   ```
   /quiz_end
   ```

--- a/app.py
+++ b/app.py
@@ -8,13 +8,13 @@ import json
 import re
 import random
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Set, Tuple
 from collections import Counter
 from difflib import SequenceMatcher
 import discord
 from discord import app_commands
-from openai import OpenAI
+from openai import AsyncOpenAI, APITimeoutError
 
 # Environment variables
 DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
@@ -27,7 +27,7 @@ client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
 
 # --- OpenAI client ---
-oai = OpenAI(api_key=OPENAI_API_KEY)
+oai = AsyncOpenAI(api_key=OPENAI_API_KEY)
 
 # Configure logging for Railway compatibility
 # Railway prefers structured JSON logs with clear levels
@@ -86,7 +86,7 @@ class QuizAnswerButton(discord.ui.Button):
             return
         
         # Check if quiz has ended
-        if datetime.utcnow() >= state["end_time"]:
+        if datetime.now(timezone.utc) >= state["end_time"]:
             quiz_logger.warning(f"User {interaction.user.name}({interaction.user.id}) attempted to answer after quiz ended in channel {interaction.channel_id}")
             await interaction.response.send_message(
                 "❌ This quiz has ended! Results are being calculated.",
@@ -118,7 +118,7 @@ class QuizAnswerButton(discord.ui.Button):
         answered_count = len(state["user_answers"][user_id])
         total_questions = len(state["questions"])
         
-        time_remaining = state["end_time"] - datetime.utcnow()
+        time_remaining = state["end_time"] - datetime.now(timezone.utc)
         minutes_remaining = int(time_remaining.total_seconds() / 60)
         seconds_remaining = int(time_remaining.total_seconds() % 60)
         
@@ -245,7 +245,7 @@ async def initialize_assistant_config():
         api_logger.info(f"Retrieving assistant configuration for {ASSISTANT_ID}")
         
         # Retrieve assistant details using beta API (still needed for this)
-        assistant = oai.beta.assistants.retrieve(assistant_id=ASSISTANT_ID)
+        assistant = await oai.beta.assistants.retrieve(assistant_id=ASSISTANT_ID)
         
         # Cache the configuration
         ASSISTANT_CONFIG["instructions"] = assistant.instructions
@@ -309,37 +309,39 @@ async def ask_assistant(user_msg: str, timeout: int = 30, temperature: float = N
         if temperature is not None:
             request_params["temperature"] = temperature
         
-        api_logger.debug(f"Creating response with model={ASSISTANT_CONFIG['model']}")
-        
-        # Create response using Responses API (non-streaming)
-        response = oai.responses.create(**request_params)
-        
+        api_logger.debug(f"Creating response with model={ASSISTANT_CONFIG['model']} timeout={timeout}s")
+
+        # Create response using Responses API (non-streaming). The timeout
+        # kwarg is honored by the OpenAI SDK and raises APITimeoutError if
+        # exceeded.
+        response = await oai.responses.create(**request_params, timeout=timeout)
+
         api_logger.info(f"Response received: id={response.id} status={response.status}")
-        
-        # Extract text from response
-        if response.output and len(response.output) > 0:
-            # Get the first output item
-            output_item = response.output[0]
-            
-            # Handle message output type
-            if hasattr(output_item, 'type') and output_item.type == 'message':
-                if hasattr(output_item, 'content'):
-                    # Extract text content
-                    chunks = []
-                    for content in output_item.content:
-                        if hasattr(content, 'type') and content.type == "output_text":
-                            text = content.text
-                            # Remove citation markers like 【4:2†source】
-                            text = re.sub(r'【[^】]*】', '', text)
-                            chunks.append(text)
-                    
-                    result = "\n".join(chunks) if chunks else "No response from assistant."
-                    api_logger.info(f"Assistant response received: length={len(result)}")
-                    return result
-        
-        api_logger.warning("No output content found in response")
-        return "No response from assistant."
-        
+
+        # Extract text from message output items. The output list can contain
+        # tool-call items (e.g. file_search_call) before the message, so we
+        # iterate every item rather than indexing [0].
+        chunks = []
+        for output_item in (response.output or []):
+            if getattr(output_item, "type", None) != "message":
+                continue
+            for content in getattr(output_item, "content", None) or []:
+                if getattr(content, "type", None) == "output_text":
+                    # Remove citation markers like 【4:2†source】
+                    text = re.sub(r'【[^】]*】', '', content.text)
+                    chunks.append(text)
+
+        if not chunks:
+            api_logger.warning("No message output content found in response")
+            return "No response from assistant."
+
+        result = "\n".join(chunks)
+        api_logger.info(f"Assistant response received: length={len(result)}")
+        return result
+
+    except APITimeoutError:
+        api_logger.error(f"OpenAI request timed out after {timeout}s")
+        return "❌ The AI took too long to respond. Please try again in a moment."
     except Exception as e:
         api_logger.error(f"Error asking assistant: {e}", exc_info=True)
         return f"❌ Error communicating with AI: {str(e)}"
@@ -994,7 +996,7 @@ async def quiz_start(interaction: discord.Interaction, topic: str = "", question
     # Shuffle the options for each question to randomize correct answer position
     shuffled_questions = [shuffle_quiz_options(q) for q in quiz_questions]
     
-    end_time = datetime.utcnow() + timedelta(minutes=duration)
+    end_time = datetime.now(timezone.utc) + timedelta(minutes=duration)
     
     QUIZ_STATE[interaction.channel_id] = {
         "questions": shuffled_questions,
@@ -1069,7 +1071,7 @@ async def quiz_answer(interaction: discord.Interaction, question_number: int, ch
         return
     
     # Check if quiz has ended
-    if datetime.utcnow() >= state["end_time"]:
+    if datetime.now(timezone.utc) >= state["end_time"]:
         discord_logger.warning(f"/quiz_answer after quiz ended in channel {interaction.channel_id} for user {interaction.user.name}({interaction.user.id})")
         await interaction.response.send_message(
             "❌ This quiz has ended! Results are being calculated.",
@@ -1102,7 +1104,7 @@ async def quiz_answer(interaction: discord.Interaction, question_number: int, ch
     answered_count = len(state["user_answers"][user_id])
     total_questions = len(state["questions"])
     
-    time_remaining = state["end_time"] - datetime.utcnow()
+    time_remaining = state["end_time"] - datetime.now(timezone.utc)
     minutes_remaining = int(time_remaining.total_seconds() / 60)
     seconds_remaining = int(time_remaining.total_seconds() % 60)
     
@@ -1167,7 +1169,7 @@ async def quiz_score(interaction: discord.Interaction):
     else:
         answered_count = len(state["user_answers"][user_id])
     
-    time_remaining = state["end_time"] - datetime.utcnow()
+    time_remaining = state["end_time"] - datetime.now(timezone.utc)
     minutes_remaining = max(0, int(time_remaining.total_seconds() / 60))
     seconds_remaining = max(0, int(time_remaining.total_seconds() % 60))
     

--- a/app.py
+++ b/app.py
@@ -702,13 +702,21 @@ def parse_quiz_response(reply: str) -> List[dict]:
 
 
 def validate_quiz_questions(items: List[dict]) -> List[dict]:
-    """Filter to questions with the required shape; normalize the answer letter."""
+    """
+    Filter to questions with the required shape; normalize the answer letter.
+    Returns shallow-copied dicts so the caller's data isn't mutated. Skips
+    any non-dict items defensively, since the bare-array fallback path in
+    parse_quiz_response doesn't enforce element shape.
+    """
     valid = []
-    for item in items:
-        if not all(k in item for k in ("q", "options", "answer", "explain")):
+    for raw in items:
+        if not isinstance(raw, dict):
             continue
-        if not isinstance(item["options"], list) or len(item["options"]) != 4:
+        if not all(k in raw for k in ("q", "options", "answer", "explain")):
             continue
+        if not isinstance(raw["options"], list) or len(raw["options"]) != 4:
+            continue
+        item = dict(raw)
         item["answer"] = str(item["answer"]).strip().upper()
         if item["answer"] not in ("A", "B", "C", "D"):
             continue
@@ -832,18 +840,25 @@ async def auto_end_quiz(channel_id: int, channel, duration_minutes: int):
     
     try:
         await asyncio.sleep(duration_minutes * 60)
-        
+
         # Check if quiz still exists
         state = QUIZ_STATE.get(channel_id)
         if not state:
             quiz_logger.warning(f"Auto-end: quiz no longer exists in channel {channel_id}")
             return
-        
+
         quiz_logger.info(f"Auto-ending quiz in channel {channel_id} after {duration_minutes} minutes")
-        
+
         # Calculate and display results
         await display_quiz_results(channel, channel_id)
-        
+
+    except asyncio.CancelledError:
+        # /quiz_end cancels this task; that's expected, not an error. The
+        # `except Exception` arm below would not catch this in Python 3.8+
+        # (CancelledError inherits from BaseException), but be explicit so
+        # the cancellation path is visible to readers.
+        quiz_logger.debug(f"Auto-end task cancelled for channel {channel_id}")
+        raise
     except Exception as e:
         quiz_logger.error(f"Error in auto_end_quiz for channel {channel_id}: {e}", exc_info=True)
 

--- a/app.py
+++ b/app.py
@@ -118,12 +118,10 @@ class QuizAnswerButton(discord.ui.Button):
         answered_count = len(state["user_answers"][user_id])
         total_questions = len(state["questions"])
         
-        time_remaining = state["end_time"] - datetime.now(timezone.utc)
-        minutes_remaining = int(time_remaining.total_seconds() / 60)
-        seconds_remaining = int(time_remaining.total_seconds() % 60)
-        
+        minutes_remaining, seconds_remaining = format_time_remaining(state["end_time"])
+
         quiz_logger.debug(f"User {interaction.user.name}({user_id}) progress: {answered_count}/{total_questions} answered, {minutes_remaining}m {seconds_remaining}s remaining")
-        
+
         await interaction.response.send_message(
             f"📝 Answer **{self.choice}** recorded for question {self.question_idx + 1}!\n"
             f"📊 You've answered {answered_count}/{total_questions} questions.\n"
@@ -171,12 +169,15 @@ async def check_bot_permissions(interaction: discord.Interaction) -> Tuple[bool,
     # Get bot's effective permissions in the channel
     bot_perms = channel.permissions_for(bot_member)
     
-    # Define required permissions
+    # Define required permissions. `use_application_commands` is what gates
+    # slash commands from appearing in the first place, so missing it is a
+    # very common cause of "the bot doesn't see my command".
     required_perms = {
         "send_messages": "Send Messages",
         "embed_links": "Embed Links",
         "read_message_history": "Read Message History",
-        "view_channel": "View Channel"
+        "view_channel": "View Channel",
+        "use_application_commands": "Use Application Commands",
     }
     
     # Check which permissions are missing
@@ -233,8 +234,13 @@ async def check_bot_permissions(interaction: discord.Interaction) -> Tuple[bool,
     error_parts.append("1. Check channel permission overwrites for roles/members")
     error_parts.append("2. Grant the bot's role the required permissions server-wide, OR")
     error_parts.append("3. Add channel-specific permission overwrites to allow the bot")
-    
-    return False, "\n".join(error_parts)
+
+    message = "\n".join(error_parts)
+    # Discord interaction messages cap at 2000 chars. With many roles/blockers
+    # this diagnostic can blow past that and the whole send fails silently.
+    if len(message) > 1900:
+        message = message[:1897] + "..."
+    return False, message
 
 async def initialize_assistant_config():
     """
@@ -276,6 +282,22 @@ async def initialize_assistant_config():
         return False
 
 
+def model_supports_temperature(model: Optional[str]) -> bool:
+    """
+    Reasoning models (o1, o3, o4) and the gpt-5 family reject the temperature
+    parameter entirely. Default to True for unknown models.
+    """
+    if not model:
+        return True
+    lower = model.lower()
+    return not (
+        lower.startswith("o1")
+        or lower.startswith("o3")
+        or lower.startswith("o4")
+        or lower.startswith("gpt-5")
+    )
+
+
 async def ask_assistant(
     user_msg: str,
     timeout: int = 30,
@@ -313,8 +335,9 @@ async def ask_assistant(
                 }
             ]
 
-        # Add optional parameters if provided
-        if temperature is not None:
+        # Add optional parameters if provided. Skip temperature for models
+        # that reject it (reasoning models, gpt-5 family) to avoid 400 errors.
+        if temperature is not None and model_supports_temperature(ASSISTANT_CONFIG.get("model")):
             request_params["temperature"] = temperature
 
         # Structured outputs are passed via the Responses-API `text.format` slot.
@@ -357,6 +380,59 @@ async def ask_assistant(
     except Exception as e:
         api_logger.error(f"Error asking assistant: {e}", exc_info=True)
         return f"❌ Error communicating with AI: {str(e)}"
+
+
+def format_time_remaining(end_time: datetime) -> Tuple[int, int]:
+    """
+    Return (minutes, seconds) of time remaining until end_time, bounded at 0
+    so callers don't display negative durations during the race between an
+    end-time check and a display update.
+    """
+    delta = end_time - datetime.now(timezone.utc)
+    total = max(0, int(delta.total_seconds()))
+    return total // 60, total % 60
+
+
+def truncate_for_discord(text: str, limit: int = 2000) -> str:
+    """
+    Truncate text to fit Discord's per-message char limit, closing any open
+    triple-backtick fence so markdown rendering doesn't break.
+    """
+    if len(text) <= limit:
+        return text
+    # Reserve room for the ellipsis and a possible closing fence on its own line.
+    head = text[: limit - 8]
+    if head.count("```") % 2 == 1:
+        head = head.rstrip() + "\n```"
+    return head + "..."
+
+
+def chunk_mentions(user_ids: List[str], base_name: str, max_chars: int = 1024) -> List[Tuple[str, str]]:
+    """
+    Pack a list of user IDs into Discord embed fields under the 1024-char value
+    limit. Returns a list of (field_name, field_value) tuples; pages are
+    suffixed when more than one field is needed.
+    """
+    if not user_ids:
+        return []
+    pages: List[str] = []
+    current: List[str] = []
+    current_len = 0
+    for uid in user_ids:
+        mention = f"<@{uid}>"
+        addition = len(mention) + (2 if current else 0)  # ", " separator
+        if current and current_len + addition > max_chars:
+            pages.append(", ".join(current))
+            current = [mention]
+            current_len = len(mention)
+        else:
+            current.append(mention)
+            current_len += addition
+    if current:
+        pages.append(", ".join(current))
+    if len(pages) == 1:
+        return [(base_name, pages[0])]
+    return [(f"{base_name} ({i+1}/{len(pages)})", page) for i, page in enumerate(pages)]
 
 
 def format_mcq(question: str, options: List[str], question_num: int = None, total: int = None) -> discord.Embed:
@@ -821,11 +897,29 @@ async def display_quiz_results(channel, channel_id: int):
     )
     
     if scores_sorted:
-        leaderboard_text = "\n".join(
+        # Pack score lines into multiple fields if needed to stay under
+        # Discord's 1024-char per-field-value limit (~20 lines per field).
+        lines = [
             f"{'🥇' if i == 0 else '🥈' if i == 1 else '🥉' if i == 2 else '📊'} <@{uid}>: **{score}/{total_questions}** ({int(score/total_questions*100)}%)"
             for i, (uid, score) in enumerate(scores_sorted)
-        )
-        leaderboard_embed.add_field(name="Final Scores", value=leaderboard_text, inline=False)
+        ]
+        pages: List[str] = []
+        current: List[str] = []
+        current_len = 0
+        for line in lines:
+            addition = len(line) + (1 if current else 0)  # newline separator
+            if current and current_len + addition > 1024:
+                pages.append("\n".join(current))
+                current = [line]
+                current_len = len(line)
+            else:
+                current.append(line)
+                current_len += addition
+        if current:
+            pages.append("\n".join(current))
+        for i, page in enumerate(pages):
+            name = "Final Scores" if len(pages) == 1 else f"Final Scores ({i+1}/{len(pages)})"
+            leaderboard_embed.add_field(name=name, value=page, inline=False)
         quiz_logger.info(f"Leaderboard: {[(uid, score) for uid, score in scores_sorted]}")
     else:
         leaderboard_embed.description = "No one submitted answers!"
@@ -865,25 +959,12 @@ async def display_quiz_results(channel, channel_id: int):
         quiz_logger.debug(f"Question {idx+1} correct users: {correct_users}")
         quiz_logger.debug(f"Question {idx+1} incorrect users: {incorrect_users}")
         
-        # Show who answered correctly
-        if correct_users:
-            correct_mentions = ", ".join(f"<@{uid}>" for uid in correct_users)
-            quiz_logger.debug(f"Question {idx+1} correct mentions string (len={len(correct_mentions)}): {correct_mentions}")
-            result_embed.add_field(
-                name="✅ Answered Correctly",
-                value=correct_mentions,
-                inline=False
-            )
-        
-        # Show who answered incorrectly
-        if incorrect_users:
-            incorrect_mentions = ", ".join(f"<@{uid}>" for uid in incorrect_users)
-            quiz_logger.debug(f"Question {idx+1} incorrect mentions string (len={len(incorrect_mentions)}): {incorrect_mentions}")
-            result_embed.add_field(
-                name="❌ Answered Incorrectly",
-                value=incorrect_mentions,
-                inline=False
-            )
+        # Show who answered correctly / incorrectly, chunked to stay under
+        # Discord's 1024-char per-field-value limit.
+        for name, value in chunk_mentions(correct_users, "✅ Answered Correctly"):
+            result_embed.add_field(name=name, value=value, inline=False)
+        for name, value in chunk_mentions(incorrect_users, "❌ Answered Incorrectly"):
+            result_embed.add_field(name=name, value=value, inline=False)
         
         # Show explanation
         result_embed.add_field(
@@ -924,12 +1005,14 @@ async def ask_command(interaction: discord.Interaction, question: str):
     api_logger.debug(f"Sending question to assistant API: '{enhanced_question[:100]}'")
     answer = await ask_assistant(enhanced_question)
     api_logger.debug(f"Received answer from assistant API (length={len(answer)})")
-    
-    # Discord has a 2000 character limit
-    if len(answer) > 1998:
-        answer = answer[:1997] + "..."
-        api_logger.warning(f"Answer truncated to 1998 characters")
-    
+
+    # Discord has a 2000 character limit per message; close any open code fence
+    # before truncating so markdown rendering doesn't break.
+    original_len = len(answer)
+    answer = truncate_for_discord(answer)
+    if len(answer) != original_len:
+        api_logger.warning(f"Answer truncated from {original_len} to {len(answer)} characters")
+
     await interaction.followup.send(answer)
     discord_logger.info(f"/ask completed for user {interaction.user.name}({interaction.user.id})")
 
@@ -954,10 +1037,10 @@ async def quiz_start(interaction: discord.Interaction, topic: str = "", question
         )
         return
     
-    if duration < 1 or duration > 480:
+    if duration < 1 or duration > 60:
         discord_logger.warning(f"/quiz_start invalid duration {duration} from user {interaction.user.name}({interaction.user.id})")
         await interaction.response.send_message(
-            "❌ Please choose a duration between 1 and 480 minutes.",
+            "❌ Please choose a duration between 1 and 60 minutes.",
             ephemeral=True
         )
         return
@@ -1100,12 +1183,10 @@ async def quiz_answer(interaction: discord.Interaction, question_number: int, ch
     answered_count = len(state["user_answers"][user_id])
     total_questions = len(state["questions"])
     
-    time_remaining = state["end_time"] - datetime.now(timezone.utc)
-    minutes_remaining = int(time_remaining.total_seconds() / 60)
-    seconds_remaining = int(time_remaining.total_seconds() % 60)
-    
+    minutes_remaining, seconds_remaining = format_time_remaining(state["end_time"])
+
     quiz_logger.debug(f"User {interaction.user.name}({user_id}) progress: {answered_count}/{total_questions} answered, {minutes_remaining}m {seconds_remaining}s remaining")
-    
+
     await interaction.response.send_message(
         f"📝 Answer recorded for question {question_number}!\n"
         f"📊 You've answered {answered_count}/{total_questions} questions.\n"
@@ -1126,22 +1207,45 @@ async def quiz_end(interaction: discord.Interaction):
         await interaction.response.send_message(perm_error, ephemeral=True)
         return
     
-    if interaction.channel_id not in QUIZ_STATE:
+    state = QUIZ_STATE.get(interaction.channel_id)
+    if state is None:
         discord_logger.warning(f"/quiz_end no quiz in channel {interaction.channel_id}")
         await interaction.response.send_message(
             "❌ No quiz is running in this channel.",
             ephemeral=True
         )
         return
-    
+
+    # Only the initiator or a moderator (manage_messages in guild channels)
+    # may end the quiz. In DMs there's no manage_messages so only the
+    # initiator qualifies — which is fine since DMs are 1:1 anyway.
+    initiator_id = state.get("initiator")
+    is_initiator = interaction.user.id == initiator_id
+    is_mod = (
+        interaction.guild is not None
+        and interaction.channel.permissions_for(interaction.user).manage_messages
+    )
+    if not (is_initiator or is_mod):
+        discord_logger.warning(
+            f"/quiz_end refused: user {interaction.user.name}({interaction.user.id}) is "
+            f"neither initiator ({initiator_id}) nor moderator in channel {interaction.channel_id}"
+        )
+        await interaction.response.send_message(
+            f"❌ Only the quiz initiator (<@{initiator_id}>) or a moderator can end this quiz.",
+            ephemeral=True,
+        )
+        return
+
     await interaction.response.defer()
-    
+
     quiz_logger.info(f"Quiz manually ended in channel {interaction.channel_id} by user {interaction.user.name}({interaction.user.id})")
-    
+
     # Display results
     await display_quiz_results(interaction.channel, interaction.channel_id)
-    
-    await interaction.followup.send("🛑 Quiz ended by moderator.")
+
+    await interaction.followup.send(
+        f"🛑 Quiz ended by <@{interaction.user.id}>."
+    )
 
 
 @tree.command(name="quiz_score", description="Check your quiz progress")
@@ -1165,9 +1269,7 @@ async def quiz_score(interaction: discord.Interaction):
     else:
         answered_count = len(state["user_answers"][user_id])
     
-    time_remaining = state["end_time"] - datetime.now(timezone.utc)
-    minutes_remaining = max(0, int(time_remaining.total_seconds() / 60))
-    seconds_remaining = max(0, int(time_remaining.total_seconds() % 60))
+    minutes_remaining, seconds_remaining = format_time_remaining(state["end_time"])
     
     # Show which questions have been answered
     answered_questions = []
@@ -1209,7 +1311,14 @@ async def info_command(interaction: discord.Interaction):
     embed.add_field(name="Version", value="1.0.0", inline=True)
     embed.add_field(
         name="Commands",
-        value="• `/ask` - Ask questions\n• `/quiz_start` - Start timed quiz\n• `/quiz_answer` - Answer question\n• `/quiz_score` - View progress\n• `/quiz_end` - End quiz",
+        value=(
+            "• `/ask` - Ask questions about the documentation\n"
+            "• `/quiz_start` - Start a timed quiz (1-60 min, 1-10 questions)\n"
+            "• `/quiz_answer` - Submit an answer by question number (alternative to buttons)\n"
+            "• `/quiz_score` - View your progress in the running quiz\n"
+            "• `/quiz_end` - End the running quiz (initiator/mod only)\n"
+            "• `/info` - Show this info panel"
+        ),
         inline=False
     )
     embed.set_footer(text="Powered by OpenAI Responses API")

--- a/app.py
+++ b/app.py
@@ -276,18 +276,26 @@ async def initialize_assistant_config():
         return False
 
 
-async def ask_assistant(user_msg: str, timeout: int = 30, temperature: float = None) -> str:
+async def ask_assistant(
+    user_msg: str,
+    timeout: int = 30,
+    temperature: float = None,
+    response_format: Optional[dict] = None,
+) -> str:
     """
     Ask the OpenAI Assistant a question using Responses API.
     Uses File Search to ground responses in the uploaded PDF.
-    
+
     Args:
         user_msg: The message/prompt to send to the assistant
         timeout: Maximum seconds to wait for response
         temperature: Optional temperature for response generation (0.0-2.0)
+        response_format: Optional OpenAI structured-output format dict (e.g. a
+            json_schema spec). When provided, forces the model to return valid
+            JSON matching the schema, eliminating fragile post-hoc parsing.
     """
-    api_logger.debug(f"ask_assistant called: msg_len={len(user_msg)} timeout={timeout} temperature={temperature}")
-    
+    api_logger.debug(f"ask_assistant called: msg_len={len(user_msg)} timeout={timeout} temperature={temperature} structured={response_format is not None}")
+
     try:
         # Build request parameters for Responses API
         request_params = {
@@ -295,7 +303,7 @@ async def ask_assistant(user_msg: str, timeout: int = 30, temperature: float = N
             "instructions": ASSISTANT_CONFIG["instructions"],
             "input": user_msg,
         }
-        
+
         # Add file search tool if vector stores are configured
         if ASSISTANT_CONFIG["vector_store_ids"]:
             request_params["tools"] = [
@@ -304,11 +312,15 @@ async def ask_assistant(user_msg: str, timeout: int = 30, temperature: float = N
                     "vector_store_ids": ASSISTANT_CONFIG["vector_store_ids"]
                 }
             ]
-        
+
         # Add optional parameters if provided
         if temperature is not None:
             request_params["temperature"] = temperature
-        
+
+        # Structured outputs are passed via the Responses-API `text.format` slot.
+        if response_format is not None:
+            request_params["text"] = {"format": response_format}
+
         api_logger.debug(f"Creating response with model={ASSISTANT_CONFIG['model']} timeout={timeout}s")
 
         # Create response using Responses API (non-streaming). The timeout
@@ -389,41 +401,28 @@ def format_mcq(question: str, options: List[str], question_num: int = None, tota
 def shuffle_quiz_options(question: dict) -> dict:
     """
     Shuffle the options in a quiz question and update the correct answer letter.
-    Returns a new dict with shuffled options and updated answer.
+    Returns a new dict with shuffled options + updated answer; preserves every
+    other field from the original (topic, page, and anything else the LLM
+    emits).
     """
     # Get the original correct answer index (A=0, B=1, C=2, D=3)
     answer_letter = question["answer"].strip().upper()
     answer_index = ord(answer_letter) - ord('A')
-    
-    # Create a list of (option_text, is_correct) tuples
+
     options_with_correctness = [
-        (opt, i == answer_index) 
+        (opt, i == answer_index)
         for i, opt in enumerate(question["options"])
     ]
-    
-    # Shuffle the options
     random.shuffle(options_with_correctness)
-    
-    # Find the new position of the correct answer
+
     new_answer_index = next(
-        i for i, (_, is_correct) in enumerate(options_with_correctness) 
+        i for i, (_, is_correct) in enumerate(options_with_correctness)
         if is_correct
     )
-    
-    # Create the shuffled question, preserving optional fields
-    shuffled_question = {
-        "q": question["q"],
-        "options": [opt for opt, _ in options_with_correctness],
-        "answer": chr(ord('A') + new_answer_index),
-        "explain": question["explain"]
-    }
-    
-    # Preserve optional topic and page fields if present
-    if "topic" in question:
-        shuffled_question["topic"] = question["topic"]
-    if "page" in question:
-        shuffled_question["page"] = question["page"]
-    
+
+    shuffled_question = dict(question)
+    shuffled_question["options"] = [opt for opt, _ in options_with_correctness]
+    shuffled_question["answer"] = chr(ord('A') + new_answer_index)
     return shuffled_question
 
 
@@ -569,199 +568,185 @@ def deduplicate_questions(questions: List[dict]) -> Tuple[List[dict], List[str]]
     return unique, topics
 
 
+# OpenAI Responses-API structured-output spec for quiz generation. The model
+# is forced to return an object with a `questions` array whose items have all
+# required fields (including `topic`, which the dedup logic depends on).
+QUIZ_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "name": "quiz_questions",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "questions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "q": {"type": "string"},
+                        "options": {"type": "array", "items": {"type": "string"}},
+                        "answer": {"type": "string", "enum": ["A", "B", "C", "D"]},
+                        "explain": {"type": "string"},
+                        "page": {"type": "integer"},
+                        "topic": {"type": "string"},
+                    },
+                    "required": ["q", "options", "answer", "explain", "page", "topic"],
+                },
+            }
+        },
+        "required": ["questions"],
+    },
+}
+
+
+def parse_quiz_response(reply: str) -> List[dict]:
+    """
+    Parse an assistant reply into a list of raw question dicts.
+    Tolerates legacy ```json fenced responses for safety; structured outputs
+    should already produce a bare JSON object.
+    """
+    reply_clean = reply.strip()
+    if reply_clean.startswith("```json"):
+        reply_clean = reply_clean[7:]
+    elif reply_clean.startswith("```"):
+        reply_clean = reply_clean[3:]
+    if reply_clean.endswith("```"):
+        reply_clean = reply_clean[:-3]
+    reply_clean = reply_clean.strip()
+
+    data = json.loads(reply_clean)
+    # Structured output: {"questions": [...]}. Permissive fallback: bare list.
+    if isinstance(data, dict) and isinstance(data.get("questions"), list):
+        return data["questions"]
+    if isinstance(data, list):
+        return data
+    return []
+
+
+def validate_quiz_questions(items: List[dict]) -> List[dict]:
+    """Filter to questions with the required shape; normalize the answer letter."""
+    valid = []
+    for item in items:
+        if not all(k in item for k in ("q", "options", "answer", "explain")):
+            continue
+        if not isinstance(item["options"], list) or len(item["options"]) != 4:
+            continue
+        item["answer"] = str(item["answer"]).strip().upper()
+        if item["answer"] not in ("A", "B", "C", "D"):
+            continue
+        valid.append(item)
+    return valid
+
+
 async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optional[List[dict]]:
     """
     Generate a quiz from the PDF using the Assistant.
-    Enforces diversity by deduplicating questions and regenerating if needed.
+    Uses OpenAI structured outputs to guarantee well-formed JSON with the
+    required topic field, then deduplicates and regenerates for diversity.
     Returns a list of question dicts or None on failure.
     """
     max_regeneration_attempts = 3
-    unique_questions = []
-    used_topics = []
-    
-    # Initial prompt with diversity requirements
-    prompt = f"""Generate {num_questions} multiple-choice questions based ONLY on the attached PDF.
 
-Requirements:
-- Each question must have exactly 4 options
-- Include the correct answer (A, B, C, or D)
-- Provide a brief explanation with page number citation
-- Focus on practical knowledge for DCS pilots
-- Ensure every question covers a different topic or concept from the PDF and avoid repeating the same keywords across multiple questions (for example, do NOT repeat 'PUSHING' or 'FUMBLE')
+    prompt = (
+        f"Generate {num_questions} multiple-choice questions based ONLY on the attached PDF.\n\n"
+        "Requirements:\n"
+        "- Each question must have exactly 4 options\n"
+        "- Provide a brief explanation with a page reference like (p.XX) in `explain`\n"
+        "- Set `page` to the integer page number from the PDF\n"
+        "- Set `topic` to a short hyphenated tag identifying the concept (e.g. \"fuel-system\", \"emergency-procedures\")\n"
+        "- Focus on practical knowledge for DCS pilots\n"
+        "- Every question must cover a different topic from the others; do not repeat distinctive keywords\n\n"
+        + (f"Topic focus: {topic_hint}" if topic_hint else "Cover various topics from the document.")
+    )
 
-{f'Topic focus: {topic_hint}' if topic_hint else 'Cover various topics from the document.'}
-
-Return ONLY a valid JSON array with this exact structure:
-[
-  {{
-    "q": "Question text here?",
-    "options": ["Option A text", "Option B text", "Option C text", "Option D text"],
-    "answer": "A",
-    "explain": "Brief explanation with page reference (p.XX)",
-    "page": 12,
-    "topic": "engine-trim"
-  }}
-]
-
-Each question MUST include:
-- "topic": A short hyphenated tag or 2-3 word phrase identifying the concept (e.g., "fuel-system", "emergency-procedures", "engine-trim")
-- "page": The page number from the PDF where this information is found
-
-If you cannot generate {num_questions} distinct topics, return fewer items with a "note" field explaining why.
-
-IMPORTANT: Return ONLY the JSON array, no other text."""
-
-    # Call assistant with diversity parameters
     api_logger.info(f"Generating quiz: topic_hint='{topic_hint}', num_questions={num_questions}")
-    reply = await ask_assistant(prompt, timeout=45, temperature=0.7)
-    
-    # Log the raw assistant reply
+    reply = await ask_assistant(
+        prompt, timeout=45, temperature=0.7, response_format=QUIZ_RESPONSE_FORMAT,
+    )
     api_logger.debug(f"Assistant raw reply (first 1000 chars): {reply[:1000]}")
-    
+
     try:
-        # Try to extract JSON from the response
-        reply_clean = reply.strip()
-        if reply_clean.startswith("```json"):
-            reply_clean = reply_clean[7:]
-        if reply_clean.startswith("```"):
-            reply_clean = reply_clean[3:]
-        if reply_clean.endswith("```"):
-            reply_clean = reply_clean[:-3]
-        
-        reply_clean = reply_clean.strip()
-        
-        data = json.loads(reply_clean)
-        
-        # Validate questions
-        valid_questions = []
-        for item in data:
-            if all(k in item for k in ("q", "options", "answer", "explain")):
-                if len(item["options"]) == 4:
-                    item["answer"] = item["answer"].strip().upper()
-                    if item["answer"] in ["A", "B", "C", "D"]:
-                        valid_questions.append(item)
-        
+        valid_questions = validate_quiz_questions(parse_quiz_response(reply))
+
         if not valid_questions:
             api_logger.warning("No valid questions returned from assistant")
             return None
-        
-        # Deduplicate initial set
+
         unique_questions, used_topics = deduplicate_questions(valid_questions)
-        api_logger.info(f"After deduplication: {len(unique_questions)} unique out of {len(valid_questions)} initial questions")
+        api_logger.info(
+            f"After deduplication: {len(unique_questions)} unique out of "
+            f"{len(valid_questions)} initial questions"
+        )
         api_logger.info(f"Used topics: {used_topics}")
-        
+
         # Regeneration loop if we don't have enough unique questions
         attempt = 0
         while len(unique_questions) < num_questions and attempt < max_regeneration_attempts:
             attempt += 1
             needed = num_questions - len(unique_questions)
-            
-            api_logger.info(f"Regeneration attempt {attempt}/{max_regeneration_attempts}: need {needed} more questions")
-            
-            # Build regeneration prompt with excluded topics
-            regen_prompt = f"""Generate {needed + 2} additional multiple-choice questions based ONLY on the attached PDF.
+            api_logger.info(
+                f"Regeneration attempt {attempt}/{max_regeneration_attempts}: "
+                f"need {needed} more questions"
+            )
 
-IMPORTANT: Do NOT generate questions about these topics (already covered): {', '.join(used_topics)}
+            regen_prompt = (
+                f"Generate {needed + 2} additional multiple-choice questions based ONLY on the attached PDF.\n\n"
+                f"Do NOT repeat any of these topics (already covered): {', '.join(used_topics)}\n\n"
+                "Same requirements as before: 4 options, A/B/C/D answer letter, explanation with page reference, integer page, hyphenated topic tag.\n"
+                "Each new question must have a unique topic tag different from the ones listed above.\n\n"
+                + (f"Topic focus: {topic_hint}" if topic_hint else "Cover various unused topics from the document.")
+            )
 
-Requirements:
-- Each question must have exactly 4 options
-- Include the correct answer (A, B, C, or D)
-- Provide a brief explanation with page number citation
-- Focus on practical knowledge for DCS pilots
-- Each question MUST cover a DIFFERENT topic from those listed above
-- Ensure every question has a unique topic tag
-
-{f'Topic focus: {topic_hint}' if topic_hint else 'Cover various topics from the document.'}
-
-Return ONLY a valid JSON array with this exact structure:
-[
-  {{
-    "q": "Question text here?",
-    "options": ["Option A text", "Option B text", "Option C text", "Option D text"],
-    "answer": "A",
-    "explain": "Brief explanation with page reference (p.XX)",
-    "page": 12,
-    "topic": "unique-topic-tag"
-  }}
-]
-
-Each question MUST include a unique "topic" tag (different from: {', '.join(used_topics)}).
-
-IMPORTANT: Return ONLY the JSON array, no other text."""
-            
-            regen_reply = await ask_assistant(regen_prompt, timeout=45, temperature=0.8)
+            regen_reply = await ask_assistant(
+                regen_prompt, timeout=45, temperature=0.8, response_format=QUIZ_RESPONSE_FORMAT,
+            )
             api_logger.debug(f"Regeneration reply (first 500 chars): {regen_reply[:500]}")
-            
+
             try:
-                # Parse regenerated questions
-                regen_clean = regen_reply.strip()
-                if regen_clean.startswith("```json"):
-                    regen_clean = regen_clean[7:]
-                if regen_clean.startswith("```"):
-                    regen_clean = regen_clean[3:]
-                if regen_clean.endswith("```"):
-                    regen_clean = regen_clean[:-3]
-                
-                regen_clean = regen_clean.strip()
-                regen_data = json.loads(regen_clean)
-                
-                # Validate regenerated questions
-                regen_valid = []
-                for item in regen_data:
-                    if all(k in item for k in ("q", "options", "answer", "explain")):
-                        if len(item["options"]) == 4:
-                            item["answer"] = item["answer"].strip().upper()
-                            if item["answer"] in ["A", "B", "C", "D"]:
-                                regen_valid.append(item)
-                
-                # Add non-duplicate questions
+                regen_valid = validate_quiz_questions(parse_quiz_response(regen_reply))
+
                 for q in regen_valid:
                     topic = extract_topic_from_question(q)
-                    
-                    # Check if similar to existing questions
-                    is_duplicate = False
-                    for existing_q, existing_topic in zip(unique_questions, used_topics):
-                        if are_questions_similar(q, existing_q, topic, existing_topic):
-                            is_duplicate = True
-                            break
-                    
+                    is_duplicate = any(
+                        are_questions_similar(q, existing_q, topic, existing_topic)
+                        for existing_q, existing_topic in zip(unique_questions, used_topics)
+                    )
                     if not is_duplicate:
                         unique_questions.append(q)
                         used_topics.append(topic)
                         api_logger.debug(f"Added new unique question with topic: {topic}")
-                        
-                        # Stop if we have enough
                         if len(unique_questions) >= num_questions:
                             break
-                
-            except (json.JSONDecodeError, Exception) as e:
-                api_logger.error(f"Error parsing regeneration attempt {attempt}: {e}")
+            except json.JSONDecodeError as e:
+                api_logger.error(f"JSON parse error in regeneration attempt {attempt}: {e}")
                 continue
-        
-        # Log final results
+
         final_count = len(unique_questions)
         api_logger.info(f"Final quiz: {final_count} unique questions (requested: {num_questions})")
         api_logger.info(f"Final topics: {used_topics}")
-        
-        # Return the requested number or what we have
+
         if final_count >= num_questions:
             result = unique_questions[:num_questions]
             api_logger.info(f"Returning {len(result)} questions")
             return result
         elif final_count > 0:
-            # Return what we have with a note
-            api_logger.warning(f"Could only generate {final_count} unique questions (requested {num_questions})")
+            api_logger.warning(
+                f"Could only generate {final_count} unique questions "
+                f"(requested {num_questions})"
+            )
             return unique_questions
         else:
             api_logger.error("Failed to generate any unique questions")
             return None
-        
+
     except json.JSONDecodeError as e:
         api_logger.error(f"JSON parse error: {e}")
         api_logger.error(f"Response was: {reply[:500]}")
         return None
     except Exception as e:
-        api_logger.error(f"Quiz generation error: {e}")
+        api_logger.error(f"Quiz generation error: {e}", exc_info=True)
         return None
 
 
@@ -790,12 +775,19 @@ async def auto_end_quiz(channel_id: int, channel, duration_minutes: int):
 async def display_quiz_results(channel, channel_id: int):
     """Display quiz results and clean up state."""
     quiz_logger.info(f"Displaying quiz results for channel {channel_id}")
-    
+
     state = QUIZ_STATE.get(channel_id)
     if not state:
         quiz_logger.warning(f"No quiz state found for channel {channel_id}")
         return
-    
+
+    # Cancel the scheduled auto-end task if it hasn't already fired. Skip when
+    # we *are* the auto-end task, since cancelling self raises CancelledError.
+    end_task = state.get("end_task")
+    if end_task and not end_task.done() and end_task is not asyncio.current_task():
+        end_task.cancel()
+        quiz_logger.debug(f"Cancelled scheduled auto-end task for channel {channel_id}")
+
     questions = state["questions"]
     user_answers = state["user_answers"]
     
@@ -1007,11 +999,15 @@ async def quiz_start(interaction: discord.Interaction, topic: str = "", question
     }
     
     quiz_logger.info(f"Quiz started in channel {interaction.channel_id} by user {interaction.user.name}({interaction.user.id}): {len(shuffled_questions)} questions, {duration} minutes")
-    
+
     topic_text = f" (Topic: {topic})" if topic else ""
-    
-    # Schedule auto-end task
-    asyncio.create_task(auto_end_quiz(interaction.channel_id, interaction.channel, duration))
+
+    # Schedule auto-end task and hold a strong reference in QUIZ_STATE so it
+    # isn't garbage-collected mid-sleep, and so /quiz_end can cancel it.
+    end_task = asyncio.create_task(
+        auto_end_quiz(interaction.channel_id, interaction.channel, duration)
+    )
+    QUIZ_STATE[interaction.channel_id]["end_task"] = end_task
     
     # Send initial message with embed
     start_embed = discord.Embed(

--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ class QuizAnswerButton(discord.ui.Button):
         if self.question_idx < 0 or self.question_idx >= len(state["questions"]):
             quiz_logger.error(f"Invalid question index {self.question_idx} for user {interaction.user.name}({interaction.user.id}) in channel {interaction.channel_id}")
             await interaction.response.send_message(
-                f"❌ Invalid question.",
+                "❌ Invalid question.",
                 ephemeral=True
             )
             return
@@ -190,7 +190,7 @@ async def check_bot_permissions(interaction: discord.Interaction) -> Tuple[bool,
         return True, None
     
     # Permissions are missing - identify the cause
-    error_parts = [f"❌ **Missing Permissions in this channel:**"]
+    error_parts = ["❌ **Missing Permissions in this channel:**"]
     error_parts.append(f"Missing: {', '.join(f'**{p}**' for p in missing_perms)}")
     error_parts.append("")
     error_parts.append("**Cause Analysis:**")
@@ -226,8 +226,8 @@ async def check_bot_permissions(interaction: discord.Interaction) -> Tuple[bool,
         error_parts.extend(blockers)
     else:
         # No explicit denies found - must be missing from base roles
-        error_parts.append(f"• The bot's roles don't grant these permissions globally")
-        error_parts.append(f"• No channel overwrites are blocking (but none are allowing either)")
+        error_parts.append("• The bot's roles don't grant these permissions globally")
+        error_parts.append("• No channel overwrites are blocking (but none are allowing either)")
     
     error_parts.append("")
     error_parts.append("**How to fix:**")
@@ -1334,7 +1334,7 @@ async def on_ready():
     await initialize_assistant_config()
     
     await tree.sync()
-    discord_logger.info(f"✈️ DarkstarAIC is online!")
+    discord_logger.info("✈️ DarkstarAIC is online!")
     discord_logger.info(f"📚 Connected to {len(client.guilds)} server(s)")
     discord_logger.info(f"🤖 Using {ASSISTANT_CONFIG['model']} with Responses API")
     discord_logger.info(f"Bot user: {client.user.name}#{client.user.discriminator} (ID: {client.user.id})")
@@ -1343,7 +1343,7 @@ async def on_ready():
     for guild in client.guilds:
         discord_logger.info(f"  - Guild: {guild.name} (ID: {guild.id}, Members: {guild.member_count})")
     
-    print(f"✈️ DarkstarAIC is online!")
+    print("✈️ DarkstarAIC is online!")
     print(f"📚 Connected to {len(client.guilds)} server(s)")
     print(f"🤖 Using {ASSISTANT_CONFIG['model']} with Responses API")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+# Conservative selection so existing code passes without a sweep. F catches
+# real bugs (undefined names, unused imports); E9/W6 catch syntax/encoding
+# issues. Expand to E/W/B/UP/I in a follow-up PR.
+select = ["F", "E9", "W6"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=8.0
+ruff>=0.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""
+Test setup. app.py reads DISCORD_TOKEN, OPENAI_API_KEY, and ASSISTANT_ID at
+import time and raises KeyError if any is missing. Populate fake values
+before any test imports the module so the import succeeds without contacting
+Discord or OpenAI (clients are constructed lazily; no requests are made).
+"""
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DISCORD_TOKEN", "test-discord-token")
+os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
+os.environ.setdefault("ASSISTANT_ID", "test-assistant-id")
+
+# Ensure the project root is importable so `import app` works regardless of
+# pytest's invocation directory.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,84 @@
+"""Tests for the dedup helpers: extract_topic, extract_keywords, similarity, dedupe."""
+import app
+
+
+def test_extract_topic_uses_topic_field():
+    q = {"q": "irrelevant text", "topic": "Radio-Procedures"}
+    assert app.extract_topic_from_question(q) == "radio-procedures"
+
+
+def test_extract_topic_strips_whitespace():
+    q = {"q": "irrelevant", "topic": "  fuel-system  "}
+    assert app.extract_topic_from_question(q) == "fuel-system"
+
+
+def test_extract_topic_falls_back_to_keywords():
+    q = {"q": "How does the engine respond when fuel pressure drops critically?"}
+    topic = app.extract_topic_from_question(q)
+    assert topic != "unknown"
+    # Top words should appear in the topic
+    assert any(word in topic for word in ("engine", "fuel", "pressure", "drops", "respond"))
+
+
+def test_extract_topic_unknown_when_only_stopwords():
+    q = {"q": "the a an of for to be"}
+    assert app.extract_topic_from_question(q) == "unknown"
+
+
+def test_extract_keywords_drops_stopwords():
+    keywords = app.extract_keywords("the radio frequency for tower communications")
+    assert "the" not in keywords
+    assert "for" not in keywords
+    assert "radio" in keywords or "tower" in keywords
+
+
+def test_extract_keywords_drops_short_words():
+    keywords = app.extract_keywords("of to be in on")
+    assert keywords == set()
+
+
+def test_similar_when_topics_match():
+    q1 = {"q": "Completely different question one"}
+    q2 = {"q": "Totally unrelated question two"}
+    assert app.are_questions_similar(q1, q2, "fuel-system", "fuel-system")
+
+
+def test_similar_when_questions_nearly_identical():
+    q1 = {"q": "What is the radio frequency for tower communications?"}
+    q2 = {"q": "What is the radio frequency for tower communication?"}
+    # Different topics on purpose; high textual similarity should still flag them
+    assert app.are_questions_similar(q1, q2, "topic-a", "topic-b")
+
+
+def test_not_similar_different_topic_different_content():
+    q1 = {"q": "What is the standard radio frequency for tower communications?"}
+    q2 = {"q": "How does engine trim affect aircraft balance during takeoff?"}
+    assert not app.are_questions_similar(q1, q2, "radio-procedures", "engine-trim")
+
+
+def test_deduplicate_keeps_first_of_duplicate_pairs():
+    questions = [
+        {"q": "Q1 about fuel", "topic": "fuel"},
+        {"q": "Q2 about engines", "topic": "engine"},
+        {"q": "Q3 also about fuel", "topic": "fuel"},
+    ]
+    unique, topics = app.deduplicate_questions(questions)
+    assert len(unique) == 2
+    assert topics == ["fuel", "engine"]
+    assert unique[0]["q"] == "Q1 about fuel"
+    assert unique[1]["q"] == "Q2 about engines"
+
+
+def test_deduplicate_with_no_topics_does_not_collapse_unrelated():
+    """
+    Regression: previously, two questions both lacking a topic field both
+    received topic 'unknown' and were treated as duplicates regardless of
+    content. extract_topic_from_question should now produce distinct
+    topics for distinct content.
+    """
+    questions = [
+        {"q": "What is the radio frequency for tower communications?"},
+        {"q": "How does engine trim affect aircraft balance during takeoff?"},
+    ]
+    unique, _ = app.deduplicate_questions(questions)
+    assert len(unique) == 2

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,115 @@
+"""Tests for the small Discord/OpenAI helpers."""
+from datetime import datetime, timedelta, timezone
+
+import app
+
+
+# --- format_time_remaining ---
+
+def test_format_time_remaining_positive():
+    end = datetime.now(timezone.utc) + timedelta(minutes=5, seconds=30)
+    minutes, seconds = app.format_time_remaining(end)
+    assert minutes == 5
+    # Allow small clock-jitter between the two datetime.now() calls
+    assert 28 <= seconds <= 30
+
+
+def test_format_time_remaining_already_past_is_zero():
+    end = datetime.now(timezone.utc) - timedelta(minutes=5)
+    minutes, seconds = app.format_time_remaining(end)
+    assert minutes == 0
+    assert seconds == 0
+
+
+def test_format_time_remaining_exactly_now_is_zero():
+    end = datetime.now(timezone.utc)
+    minutes, seconds = app.format_time_remaining(end)
+    assert minutes == 0
+    assert seconds == 0
+
+
+# --- truncate_for_discord ---
+
+def test_truncate_noop_under_limit():
+    short = "hello world"
+    assert app.truncate_for_discord(short) == short
+
+
+def test_truncate_basic_long_text():
+    long_text = "x" * 3000
+    result = app.truncate_for_discord(long_text)
+    assert len(result) <= 2000
+    assert result.endswith("...")
+
+
+def test_truncate_closes_open_triple_backtick_fence():
+    text = "before\n```python\n" + ("payload\n" * 500)
+    result = app.truncate_for_discord(text)
+    assert len(result) <= 2000
+    # An odd number of triple-backtick fences would break Discord rendering.
+    assert result.count("```") % 2 == 0
+
+
+def test_truncate_leaves_balanced_fences_alone():
+    text = "before\n```python\ncode\n```\n" + "x" * 3000
+    result = app.truncate_for_discord(text)
+    assert len(result) <= 2000
+    assert result.count("```") % 2 == 0
+
+
+# --- chunk_mentions ---
+
+def test_chunk_mentions_empty():
+    assert app.chunk_mentions([], "Players") == []
+
+
+def test_chunk_mentions_single_page_uses_base_name():
+    result = app.chunk_mentions(["123", "456"], "Players")
+    assert result == [("Players", "<@123>, <@456>")]
+
+
+def test_chunk_mentions_multi_page_paginates_name():
+    # Snowflake IDs are 17-19 digits; <@id> is ~21 chars + ", "
+    user_ids = [str(10**17 + i) for i in range(50)]
+    result = app.chunk_mentions(user_ids, "Players", max_chars=200)
+    assert len(result) > 1
+    assert result[0][0] == f"Players (1/{len(result)})"
+    for name, value in result:
+        assert len(value) <= 200
+    # Round-trip: concatenating all values should recover all mentions
+    all_mentions = ", ".join(value for _, value in result)
+    for uid in user_ids:
+        assert f"<@{uid}>" in all_mentions
+
+
+def test_chunk_mentions_respects_max_chars():
+    # 30 IDs of length ~20 chars each, force tiny chunks
+    user_ids = [str(10**17 + i) for i in range(30)]
+    result = app.chunk_mentions(user_ids, "Players", max_chars=100)
+    for _, value in result:
+        assert len(value) <= 100
+
+
+# --- model_supports_temperature ---
+
+def test_temperature_supported_for_gpt_4_family():
+    assert app.model_supports_temperature("gpt-4o-mini")
+    assert app.model_supports_temperature("gpt-4.1")
+    assert app.model_supports_temperature("gpt-4o")
+
+
+def test_temperature_rejected_for_reasoning_models():
+    assert not app.model_supports_temperature("o1-mini")
+    assert not app.model_supports_temperature("o3-pro")
+    assert not app.model_supports_temperature("o4-mini")
+
+
+def test_temperature_rejected_for_gpt5_family():
+    assert not app.model_supports_temperature("gpt-5")
+    assert not app.model_supports_temperature("gpt-5-turbo")
+
+
+def test_temperature_default_true_for_unknown_or_none():
+    assert app.model_supports_temperature(None)
+    assert app.model_supports_temperature("")
+    assert app.model_supports_temperature("some-future-model")

--- a/tests/test_quiz_parsing.py
+++ b/tests/test_quiz_parsing.py
@@ -87,3 +87,24 @@ def test_validate_rejects_non_list_options():
     items = [{**_q(), "options": "ABCD"}]
     valid = app.validate_quiz_questions(items)
     assert valid == []
+
+
+def test_validate_skips_non_dict_items():
+    """
+    parse_quiz_response's bare-array fallback doesn't enforce element shape,
+    so validate must defensively skip ints, strings, and other non-dicts
+    rather than raising TypeError on `k in item`.
+    """
+    items = [_q(), 42, "not a dict", None, [1, 2, 3], _q("Q2")]
+    valid = app.validate_quiz_questions(items)
+    assert len(valid) == 2
+    assert valid[0]["q"] == "Q1"
+    assert valid[1]["q"] == "Q2"
+
+
+def test_validate_does_not_mutate_input():
+    """Normalizing the answer letter must not modify the caller's dicts."""
+    original = {**_q(), "answer": " b "}
+    items = [original]
+    app.validate_quiz_questions(items)
+    assert original["answer"] == " b "

--- a/tests/test_quiz_parsing.py
+++ b/tests/test_quiz_parsing.py
@@ -1,0 +1,89 @@
+"""Tests for parse_quiz_response and validate_quiz_questions."""
+import json
+import pytest
+
+import app
+
+
+def _q(q="Q1", answer="A", n_opts=4):
+    return {
+        "q": q,
+        "options": [f"opt{i}" for i in range(n_opts)],
+        "answer": answer,
+        "explain": "explanation",
+        "page": 1,
+        "topic": "test-topic",
+    }
+
+
+def test_parse_bare_json_object():
+    reply = json.dumps({"questions": [_q()]})
+    result = app.parse_quiz_response(reply)
+    assert len(result) == 1
+    assert result[0]["q"] == "Q1"
+
+
+def test_parse_json_code_fence():
+    reply = "```json\n" + json.dumps({"questions": [_q("Q2", "B")]}) + "\n```"
+    result = app.parse_quiz_response(reply)
+    assert len(result) == 1
+    assert result[0]["answer"] == "B"
+
+
+def test_parse_plain_code_fence():
+    reply = "```\n" + json.dumps({"questions": [_q()]}) + "\n```"
+    result = app.parse_quiz_response(reply)
+    assert len(result) == 1
+
+
+def test_parse_bare_array_legacy_fallback():
+    """If the model returns a bare array instead of {questions: [...]}, still parse it."""
+    reply = json.dumps([_q()])
+    result = app.parse_quiz_response(reply)
+    assert len(result) == 1
+
+
+def test_parse_invalid_json_raises_json_error():
+    with pytest.raises(json.JSONDecodeError):
+        app.parse_quiz_response("not json at all")
+
+
+def test_validate_keeps_well_formed():
+    valid = app.validate_quiz_questions([_q()])
+    assert len(valid) == 1
+
+
+def test_validate_drops_missing_required_fields():
+    items = [
+        {"q": "no opts", "answer": "A", "explain": "e"},
+        {"options": ["a", "b", "c", "d"], "answer": "A", "explain": "e"},  # no q
+        _q(),  # ok
+    ]
+    valid = app.validate_quiz_questions(items)
+    assert len(valid) == 1
+    assert valid[0]["q"] == "Q1"
+
+
+def test_validate_drops_wrong_option_count():
+    items = [_q(n_opts=3), _q(n_opts=5), _q(n_opts=4)]
+    valid = app.validate_quiz_questions(items)
+    assert len(valid) == 1
+
+
+def test_validate_drops_invalid_answer_letter():
+    items = [_q(answer="E"), _q(answer="X"), _q(answer="A")]
+    valid = app.validate_quiz_questions(items)
+    assert len(valid) == 1
+    assert valid[0]["answer"] == "A"
+
+
+def test_validate_normalizes_answer_case_and_whitespace():
+    items = [{**_q(), "answer": " b "}]
+    valid = app.validate_quiz_questions(items)
+    assert valid[0]["answer"] == "B"
+
+
+def test_validate_rejects_non_list_options():
+    items = [{**_q(), "options": "ABCD"}]
+    valid = app.validate_quiz_questions(items)
+    assert valid == []

--- a/tests/test_shuffle.py
+++ b/tests/test_shuffle.py
@@ -1,0 +1,67 @@
+"""Tests for shuffle_quiz_options."""
+import random
+
+import app
+
+
+def _question(answer_idx=0):
+    """A question where the correct option is uniquely identifiable as 'correct'."""
+    options = ["wrong0", "wrong1", "wrong2", "wrong3"]
+    options[answer_idx] = "correct"
+    return {
+        "q": "Question text",
+        "options": options,
+        "answer": chr(ord("A") + answer_idx),
+        "explain": "explanation",
+        "page": 42,
+        "topic": "test-topic",
+    }
+
+
+def test_shuffle_preserves_correct_answer():
+    # Try a handful of seeds to make sure the invariant holds across permutations
+    for seed in range(20):
+        random.seed(seed)
+        q = _question(answer_idx=0)
+        shuffled = app.shuffle_quiz_options(q)
+        answer_idx = ord(shuffled["answer"]) - ord("A")
+        assert shuffled["options"][answer_idx] == "correct", (
+            f"seed={seed}: answer letter {shuffled['answer']} doesn't point at the correct option"
+        )
+
+
+def test_shuffle_preserves_all_fields():
+    q = {
+        "q": "Q1",
+        "options": ["a", "b", "c", "d"],
+        "answer": "A",
+        "explain": "e",
+        "topic": "t",
+        "page": 1,
+        "note": "should not be dropped",
+        "future_field": [1, 2, 3],
+    }
+    shuffled = app.shuffle_quiz_options(q)
+    assert shuffled["note"] == "should not be dropped"
+    assert shuffled["future_field"] == [1, 2, 3]
+    assert shuffled["topic"] == "t"
+    assert shuffled["page"] == 1
+    assert shuffled["q"] == "Q1"
+    assert shuffled["explain"] == "e"
+
+
+def test_shuffle_handles_lowercase_answer():
+    q = _question(answer_idx=2)
+    q["answer"] = "c"  # lowercase
+    shuffled = app.shuffle_quiz_options(q)
+    answer_idx = ord(shuffled["answer"]) - ord("A")
+    assert shuffled["options"][answer_idx] == "correct"
+
+
+def test_shuffle_does_not_mutate_original():
+    q = _question(answer_idx=1)
+    original_options = list(q["options"])
+    original_answer = q["answer"]
+    app.shuffle_quiz_options(q)
+    assert q["options"] == original_options
+    assert q["answer"] == original_answer


### PR DESCRIPTION
Rolling PR for the alpha-build code review. Each batch is one commit so review can happen incrementally.

## Batches

- [x] **Batch 1 — CLAUDE.md** (1d60349). Architecture, the still-required `ASSISTANT_ID` bootstrap, quiz-state lifecycle, dedup coupling, Railway gotchas. Updated through later batches to reflect fixes.
- [x] **Batch 2 — Critical correctness + perf** (26cb3ca). `AsyncOpenAI` so OpenAI calls no longer block the event loop. `ask_assistant` iterates `response.output` instead of indexing `[0]` (fixes silent "No response" when `file_search` fires first). `timeout` is actually passed to the SDK and `APITimeoutError` gets a user-friendly message. Deprecated `datetime.utcnow()` → `datetime.now(timezone.utc)`.
- [x] **Batch 3 — Quiz reliability** (7021d09). OpenAI structured outputs via a strict json_schema requiring `topic` + `page` (kills fragile fence-stripping for the happy path and stops the dedup logic from collapsing unknown-topic questions). Extracted `parse_quiz_response` / `validate_quiz_questions` helpers for unit-testing. `auto_end_quiz` task stored in `QUIZ_STATE[ch]["end_task"]` so it can't be GC'd and so `display_quiz_results` can cancel it on `/quiz_end` (with self-cancel guard). `shuffle_quiz_options` copies the original dict so unknown fields survive.
- [x] **Batch 4 — Discord limits + UX** (d84f2ac). `chunk_mentions` paginates leaderboard / correct / incorrect lists under the 1024-char field limit. Permission-error string truncated under 2000. `truncate_for_discord` closes open code fences before truncating `/ask`. `format_time_remaining` bounds countdowns at 0. `model_supports_temperature` skips temperature for reasoning models / gpt-5 family. `check_bot_permissions` now also checks `use_application_commands`. `/quiz_end` requires the initiator or `manage_messages`. Duration cap dropped from 480 → 60 minutes. README + `/info` updated.
- [x] **Batch 5 — Tests + CI** (71e0ecf). 41 unit tests for the pure helpers (parsing, validation, shuffle invariants, dedup including a regression for the unknown-topic collapse, and the four new Discord/OpenAI helpers). `pyproject.toml` with conservative ruff selection (F/E9/W6 — existing code passes; 6 trivial F541 auto-fixes included). `requirements-dev.txt` adds pytest + ruff without touching the Railway runtime requirements. `.github/workflows/ci.yml` runs ruff + pytest on push to main and every PR.

## Out of scope (follow-up PRs)

Larger items from the review left for separate discussion: persistent state (SQLite for quiz history / cross-quiz stats), spaced repetition, multi-PDF support, streaming `/ask`, per-user rate limits, splitting `app.py` into a package.

https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo