### PR TITLE
Pivot to Anthropic Claude + drop RAG vector store; add SQLite persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this is
 
-DarkstarAIC is a single-file Discord bot (`app.py`) that provides PDF-grounded Q&A and timed multiple-choice quizzes for the DCS Air Control Communication community. It uses the OpenAI Responses API (via `AsyncOpenAI`) with a `file_search` tool backed by a vector store. Deployed on Railway via Docker.
+DarkstarAIC is a single-file Discord bot (`app.py`) that provides PDF-grounded Q&A and timed multiple-choice quizzes for the DCS Air Control Communication community. It uses the Anthropic Claude API (`AsyncAnthropic`) with the Files API for PDF attachment, prompt caching for cost, and tool-use for structured quiz output. Deployed on Railway via Docker.
 
 ## Running
 
-Three environment variables are required and the bot will crash on startup without them:
+Four environment variables are required and the bot will crash on startup without them:
 
 - `DISCORD_TOKEN` — Discord bot token
-- `OPENAI_API_KEY` — OpenAI API key
-- `ASSISTANT_ID` — an existing OpenAI Assistant (still required even though the bot uses the Responses API; see "Assistant config bootstrap" below)
+- `ANTHROPIC_API_KEY` — Anthropic API key
+- `ACC_FILE_ID` — Anthropic Files-API ID for the ACC reference PDF (see "Uploading the PDF" below)
+- `CLAUDE_MODEL` — optional, defaults to `claude-haiku-4-5`. Bump to `claude-sonnet-4-6` for higher-quality quiz generation (~6× the cost).
 
 ```bash
 pip install -r requirements.txt
@@ -24,9 +25,20 @@ Docker (matches Railway production):
 ```bash
 docker build -t darkstar .
 docker run --rm \
-  -e DISCORD_TOKEN=... -e OPENAI_API_KEY=... -e ASSISTANT_ID=... \
+  -e DISCORD_TOKEN=... -e ANTHROPIC_API_KEY=... -e ACC_FILE_ID=... \
   darkstar
 ```
+
+### Uploading the PDF
+
+`scripts/upload_pdf.py` is a one-time helper:
+
+```bash
+export ANTHROPIC_API_KEY=...
+python scripts/upload_pdf.py path/to/acc_2024.pdf
+```
+
+It prints the `file_id` to set as `ACC_FILE_ID`. Re-run only when the source PDF actually changes — Anthropic stores the file indefinitely until deleted.
 
 ### Tests + lint
 
@@ -38,9 +50,9 @@ pytest tests/test_dedup.py   # one file
 pytest -k "shuffle"          # one test by keyword
 ```
 
-Tests live in `tests/` and cover the pure helpers — `parse_quiz_response`, `validate_quiz_questions`, `shuffle_quiz_options`, the dedup chain, and the small Discord/OpenAI helpers. They import `app` directly; `tests/conftest.py` populates fake env vars so the import succeeds without contacting Discord or OpenAI. The Discord/OpenAI clients in `app.py` are constructed lazily and make no requests until called, so tests don't need to mock them.
+Tests live in `tests/` and cover the pure helpers — `validate_quiz_questions`, `shuffle_quiz_options`, the dedup chain, and the small Discord helpers. They import `app` directly; `tests/conftest.py` populates fake env vars so the import succeeds without contacting Discord or Anthropic. The Discord/Anthropic clients in `app.py` are constructed lazily and make no requests until called, so tests don't need to mock them.
 
-CI lives at `.github/workflows/ci.yml` and runs ruff + pytest on push to main and on every PR. Ruff config in `pyproject.toml` is intentionally conservative (`select = ["F", "E9", "W6"]`) so existing code passes without a style sweep; expand to `E/W/B/UP/I` in a follow-up.
+CI lives at `.github/workflows/ci.yml` and runs ruff + pytest on push to main and on every PR.
 
 ## Architecture
 
@@ -48,53 +60,68 @@ CI lives at `.github/workflows/ci.yml` and runs ruff + pytest on push to main an
 
 Roughly in file order:
 
-1. **Environment + OpenAI client + logging setup** (top of file)
-2. **UI components** — `QuizAnswerButton`, `QuizQuestionView` (Discord buttons)
-3. **`check_bot_permissions`** — every slash command calls this first; produces verbose diagnostic strings when perms are missing
-4. **`initialize_assistant_config` + `ask_assistant`** — the OpenAI integration layer
-5. **Quiz pipeline** — `format_mcq`, `shuffle_quiz_options`, dedup helpers, `generate_quiz`, `auto_end_quiz`, `display_quiz_results`
-6. **Slash commands** — `/ask`, `/quiz_start`, `/quiz_answer`, `/quiz_end`, `/quiz_score`, `/info`
-7. **`on_ready` + `client.run()`**
+1. **Environment + Anthropic client + logging setup** (top of file)
+2. **`ACC_INSTRUCTIONS`** — the system prompt as a module-level constant. Edit directly and redeploy to change tone or refusal behavior.
+3. **UI components** — `QuizAnswerButton`, `QuizQuestionView` (Discord buttons)
+4. **`check_bot_permissions`** — every slash command calls this first; produces verbose diagnostic strings when perms are missing
+5. **`ask_assistant`** — the Claude integration layer (handles both plain text and forced tool-use)
+6. **Quiz pipeline** — `format_mcq`, `shuffle_quiz_options`, dedup helpers, `QUIZ_TOOL`, `validate_quiz_questions`, `_request_quiz_questions`, `generate_quiz`, `auto_end_quiz`, `display_quiz_results`
+7. **Slash commands** — `/ask`, `/quiz_start`, `/quiz_answer`, `/quiz_end`, `/quiz_score`, `/info`
+8. **`on_ready` + `client.run()`**
 
-### Assistant config bootstrap
+### PDF grounding via the Files API
 
-The bot was migrated from the Assistants API to the Responses API (see `MIGRATION_NOTES.md`), but it still uses `oai.beta.assistants.retrieve(ASSISTANT_ID)` at startup to read the assistant's `instructions`, `model`, and `vector_store_ids`. Those are cached in the module-level `ASSISTANT_CONFIG` dict and used to build every Responses API request. **Before `on_ready` completes, `ASSISTANT_CONFIG` values are all `None`** — any code path that runs before bot startup will see empty config.
+The ACC PDF is uploaded once to Anthropic (see "Uploading the PDF") and referenced by `file_id` in every request. `ask_assistant` builds a request with:
+
+- `system`: `ACC_INSTRUCTIONS` (cached)
+- `messages[0].content`: `[document(file_id=ACC_FILE_ID, cache_control=ephemeral), text(user_msg)]`
+- `betas=["files-api-2025-04-14"]` to enable the Files API beta
+
+Both the system prompt and the document block are marked `cache_control: {"type": "ephemeral"}` so the ~50K-token prefix is served from cache (~10% of base input price) on every request after the first one in a 5-minute window. The varying user question lands *after* the document block, so it doesn't invalidate the cached prefix.
+
+Verify caching is working by inspecting `usage.cache_read_input_tokens` in the logs — if it's zero across repeated requests, something is invalidating the prefix (likely an interpolated date or user-id into `ACC_INSTRUCTIONS`).
 
 ### Quiz state
 
 `QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id`. Each entry holds the question list (shuffled), per-user answers, end time, duration, initiator user ID, and the `auto_end_quiz` task handle.
 
-**This is in-memory only.** Any process restart (deploy, Railway OOM, crash) wipes all in-flight quizzes with no recovery. Only one quiz per channel at a time.
+**This is in-memory only.** Any process restart (deploy, Railway OOM, crash) wipes all in-flight quizzes with no recovery. Only one quiz per channel at a time. Persisting this is the next planned change.
 
 `auto_end_quiz` is scheduled via `asyncio.create_task(...)` at quiz start; the task handle is stored in `state["end_task"]` to keep it from being GC'd and so `display_quiz_results` can cancel it on manual `/quiz_end`. The cancel path skips itself when invoked from inside the auto-end task to avoid `CancelledError` on self.
 
 ### Quiz generation pipeline
 
-`generate_quiz` is the most complex function. The flow:
+`generate_quiz` uses forced tool-use against `QUIZ_TOOL`:
 
-1. Build prompt asking for N MCQs covering distinct topics
-2. Call `ask_assistant` with `temperature=0.7` and `response_format=QUIZ_RESPONSE_FORMAT` (strict json_schema requiring `q`, `options`, `answer` ∈ {A,B,C,D}, `explain`, `page`, `topic`)
-3. `parse_quiz_response` extracts the `questions` array (with permissive ```` ```json ```` fence stripping as a fallback)
-4. `validate_quiz_questions` filters to items with exactly 4 options and a valid answer letter
-5. Run `deduplicate_questions` (see below)
-6. If under target count, regenerate up to 3 times at `temperature=0.8` with an "exclude these topics" prompt (also schema-constrained)
-7. Shuffle each question's options via `shuffle_quiz_options` (re-letters the correct answer, preserves every other field)
+1. Build a prompt asking for N MCQs.
+2. Call `ask_assistant(prompt, tool=QUIZ_TOOL, temperature=0.7)`. The `tool_choice` is set to force `submit_quiz`, so Claude must call it.
+3. Claude's response contains a `tool_use` block whose `input` is the parsed dict — no JSON-string parsing, no fence-stripping needed.
+4. `validate_quiz_questions` filters to items with exactly 4 options and a valid answer letter (defense in depth — the schema enforces this on Claude's side too).
+5. Run `deduplicate_questions` (see below).
+6. If under target count, regenerate up to 3 times at `temperature=0.8` with an "exclude these topics" prompt.
+7. Shuffle each question's options via `shuffle_quiz_options` (re-letters the correct answer, preserves every other field).
 
 ### Deduplication
 
 Three signals in `are_questions_similar`:
 
-1. **Exact topic-tag match** — short-circuits to `True`. Because `QUIZ_RESPONSE_FORMAT` makes `topic` required, this no longer collapses multiple "unknown" questions into one (the previous behavior).
+1. **Exact topic-tag match** — short-circuits to `True`. Because `QUIZ_TOOL`'s `input_schema` makes `topic` required, this cannot collapse multiple "unknown" questions into one.
 2. Fuzzy text ratio > 85% via `difflib.SequenceMatcher`
 3. Top-5 keyword overlap > 40% (after stopword removal)
 
 If you touch the schema and remove the `topic` requirement, restore the validation guard before relying on the dedup logic — they're coupled.
 
-### Response parsing in `ask_assistant`
+### Response handling in `ask_assistant`
 
-Citation markers like `【4:2†source】` are stripped via regex before returning. The code iterates every item in `response.output` looking for `message` types and skips tool-call items (e.g. `file_search_call`), so a tool-call landing before the message no longer swallows the response.
+`ask_assistant` accepts an optional `tool` dict. When provided:
 
-`ask_assistant` also accepts a `response_format` dict that gets wired into the Responses-API `text.format` slot for structured outputs. Pass `model_supports_temperature(model)` is consulted before sending `temperature` — reasoning models (o1/o3/o4) and the gpt-5 family reject it.
+- The request includes `tools=[tool]` and `tool_choice={"type": "tool", "name": tool["name"]}`.
+- The return value is the `tool_use.input` dict, not a string.
+- Returns `None` (instead of an error string) on refusal / timeout so the caller can branch cleanly.
+
+When `tool` is omitted, the return value is a plain text string (the concatenation of all `text` blocks in `response.content`). The `refusal` stop reason is handled explicitly with a user-friendly message.
+
+Token-usage details (input, cache-read, cache-write, output) are logged on every successful response.
 
 ### Permissions
 
@@ -112,7 +139,7 @@ If you display user mentions or LLM-generated prose, route through these rather 
 
 ### Logging
 
-Four named loggers — `__main__`, `discord_bot`, `quiz`, `openai_api` — all to stdout (Railway captures stdout). Format includes `funcName:lineno`. Debug-level logs include raw user answer dicts.
+Four named loggers — `__main__`, `discord_bot`, `quiz`, `anthropic_api` — all to stdout (Railway captures stdout). Format includes `funcName:lineno`. Debug-level logs include raw user answer dicts. The API logger emits token-usage breakdowns (input / cache-read / cache-write / output) on every Claude response so you can verify caching is hitting.
 
 ## Slash command sync
 
@@ -122,4 +149,4 @@ Four named loggers — `__main__`, `discord_bot`, `quiz`, `openai_api` — all t
 
 - `Dockerfile` runs as non-root `appuser` (uid 1000) and sets `MALLOC_ARENA_MAX=2` to reduce glibc fragmentation
 - `railway.json` configures `ON_FAILURE` restart with up to 10 retries — combined with in-memory quiz state, this means a flaky deploy can silently wipe active quizzes multiple times
-- `h11==0.16.0` is pinned in `requirements.txt` for a security fix; if you bump `discord.py` or `openai`, verify `h11` compatibility
+- `h11==0.16.0` is pinned in `requirements.txt` for a security fix; if you bump `discord.py` or `anthropic`, verify `h11` compatibility

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 **AI-powered Q&A and Quiz Discord Bot for Air Intercept Control and Air Control Communication**
 
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![Discord.py](https://img.shields.io/badge/discord.py-2.4.0-blue.svg)](https://github.com/Rapptz/discord.py)
-[![OpenAI](https://img.shields.io/badge/OpenAI-GPT--4.1--mini-green.svg)](https://platform.openai.com/)
+[![Discord.py](https://img.shields.io/badge/discord.py-2.7.1-blue.svg)](https://github.com/Rapptz/discord.py)
+[![Anthropic](https://img.shields.io/badge/Anthropic-Claude-orange.svg)](https://www.anthropic.com/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Support-orange.svg)](https://www.buymeacoffee.com/joemurrell)
 
-DarkstarAIC is a Discord bot designed for DCS (Digital Combat Simulator) communities, providing intelligent question-answering and interactive quizzes based on Air Control Communication (ACC) documentation. Powered by OpenAI's GPT-4.1-mini with Assistants API v2, it delivers accurate, PDF-grounded responses to help pilots and controllers master ACC procedures. FOR SIMULATION USE ONLY.
+DarkstarAIC is a Discord bot designed for DCS (Digital Combat Simulator) communities, providing intelligent question-answering and interactive quizzes based on Air Control Communication (ACC) documentation. Powered by Anthropic's Claude API with the Files API for PDF grounding, prompt caching, and tool-use structured output, it delivers accurate page-referenced answers to help pilots and controllers master ACC procedures. FOR SIMULATION USE ONLY.
 
 ## ✨ Features
 
@@ -16,7 +16,7 @@ DarkstarAIC is a Discord bot designed for DCS (Digital Combat Simulator) communi
 - **🎯 Interactive Quizzes**: Test your knowledge with automatically generated multiple-choice quizzes
 - **⏱️ Timed Quiz Sessions**: Create time-limited quizzes (1-60 minutes) with customizable question counts
 - **🔍 Smart Topic Diversity**: Quiz questions cover diverse topics from the documentation
-- **🤖 GPT-4.1-mini Powered**: Leverages OpenAI's latest model for intelligent, context-aware responses
+- **🤖 Claude Haiku 4.5**: Fast, cost-efficient Claude model with native PDF understanding and prompt caching (~10% input cost for the cached PDF prefix)
 
 
 ## 📺 Demo

--- a/app.py
+++ b/app.py
@@ -1,33 +1,41 @@
 """
 DarkstarAIC - DCS Air Control Communication Discord Bot
-PDF-grounded Q&A and Quiz system using OpenAI Responses API
+PDF-grounded Q&A and Quiz system using the Anthropic Claude API
+(Files API for PDF attachment + prompt caching + tool-use structured output).
 """
 import os
 import asyncio
-import json
-import re
 import random
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Set, Tuple
+from typing import List, Optional, Set, Tuple, Union
 from collections import Counter
 from difflib import SequenceMatcher
+import re
 import discord
 from discord import app_commands
-from openai import AsyncOpenAI, APITimeoutError
+from anthropic import AsyncAnthropic, APITimeoutError
 
 # Environment variables
 DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
-OPENAI_API_KEY = os.environ["OPENAI_API_KEY"]
-ASSISTANT_ID = os.environ["ASSISTANT_ID"]
+ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
+# File ID returned by Anthropic's Files API for the ACC reference PDF.
+# Upload once with scripts/upload_pdf.py and set the resulting value here.
+ACC_FILE_ID = os.environ["ACC_FILE_ID"]
+# Claude model to use. Defaults to Haiku 4.5 for cost; bump to
+# claude-sonnet-4-6 for higher-quality quiz generation.
+CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-haiku-4-5")
 
 # --- Discord client setup ---
 intents = discord.Intents.default()
 client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
 
-# --- OpenAI client ---
-oai = AsyncOpenAI(api_key=OPENAI_API_KEY)
+# --- Anthropic client ---
+anthropic_client = AsyncAnthropic(api_key=ANTHROPIC_API_KEY)
+
+# Beta header required for the Files API (PDF attachment via file_id).
+ANTHROPIC_BETAS = ["files-api-2025-04-14"]
 
 # Configure logging for Railway compatibility
 # Railway prefers structured JSON logs with clear levels
@@ -45,17 +53,22 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 discord_logger = logging.getLogger('discord_bot')
 quiz_logger = logging.getLogger('quiz')
-api_logger = logging.getLogger('openai_api')
+api_logger = logging.getLogger('anthropic_api')
 
 # In-memory quiz state (per-channel)
 QUIZ_STATE = {}
 
-# Assistant configuration (cached from ASSISTANT_ID)
-ASSISTANT_CONFIG = {
-    "instructions": None,
-    "model": None,
-    "vector_store_ids": []
-}
+# System prompt — defines DarkstarAIC's persona and grounding rules. Edit
+# directly to tune tone or refusal behavior; the value is cached prefix so
+# changes invalidate the prompt cache until the new prefix is re-warmed.
+ACC_INSTRUCTIONS = """You are DarkstarAIC, a flight-training assistant for the DCS (Digital Combat Simulator) Air Control Communication (ACC) community.
+
+Ground every answer in the ACC procedures PDF attached to this conversation.
+
+- Cite page numbers inline (e.g. "see p. 42") whenever you reference a procedure.
+- If the user's question can't be answered from the PDF, say so plainly rather than guessing.
+- Use precise aviation terminology; do not soften technical detail for readability.
+- For quiz generation: every question must cover a distinct concept, and each distractor must be plausibly close to the correct answer but unambiguously wrong to a knowledgeable reader."""
 
 
 # --- Button Classes for Quiz Interaction ---
@@ -242,132 +255,119 @@ async def check_bot_permissions(interaction: discord.Interaction) -> Tuple[bool,
         message = message[:1897] + "..."
     return False, message
 
-async def initialize_assistant_config():
-    """
-    Retrieve assistant configuration from the ASSISTANT_ID and cache it.
-    This is called once on startup to get instructions, model, and vector store IDs.
-    """
-    try:
-        api_logger.info(f"Retrieving assistant configuration for {ASSISTANT_ID}")
-        
-        # Retrieve assistant details using beta API (still needed for this)
-        assistant = await oai.beta.assistants.retrieve(assistant_id=ASSISTANT_ID)
-        
-        # Cache the configuration
-        ASSISTANT_CONFIG["instructions"] = assistant.instructions
-        ASSISTANT_CONFIG["model"] = assistant.model
-        
-        # Extract vector store IDs from tools
-        vector_store_ids = []
-        if assistant.tools:
-            for tool in assistant.tools:
-                if hasattr(tool, 'type') and tool.type == "file_search":
-                    if hasattr(tool, 'file_search') and hasattr(tool.file_search, 'vector_store_ids'):
-                        vector_store_ids.extend(tool.file_search.vector_store_ids)
-        
-        ASSISTANT_CONFIG["vector_store_ids"] = vector_store_ids
-        
-        api_logger.info(f"Assistant config cached: model={ASSISTANT_CONFIG['model']}, "
-                       f"vector_stores={len(vector_store_ids)}, "
-                       f"instructions_len={len(ASSISTANT_CONFIG['instructions']) if ASSISTANT_CONFIG['instructions'] else 0}")
-        
-        return True
-        
-    except Exception as e:
-        api_logger.error(f"Failed to retrieve assistant configuration: {e}", exc_info=True)
-        # Set defaults if retrieval fails
-        ASSISTANT_CONFIG["instructions"] = "You are a helpful assistant."
-        ASSISTANT_CONFIG["model"] = "gpt-4o-mini"
-        ASSISTANT_CONFIG["vector_store_ids"] = []
-        return False
-
-
 def model_supports_temperature(model: Optional[str]) -> bool:
     """
-    Reasoning models (o1, o3, o4) and the gpt-5 family reject the temperature
-    parameter entirely. Default to True for unknown models.
+    Claude Opus 4.7 removed the `temperature` parameter and returns 400 if it
+    is sent. All earlier Claude models (Sonnet 4.6, Haiku 4.5, Opus 4.6 and
+    older) accept it. Defaults to True for unknown / non-Claude models.
     """
     if not model:
         return True
-    lower = model.lower()
-    return not (
-        lower.startswith("o1")
-        or lower.startswith("o3")
-        or lower.startswith("o4")
-        or lower.startswith("gpt-5")
-    )
+    return not model.startswith("claude-opus-4-7")
 
 
 async def ask_assistant(
     user_msg: str,
     timeout: int = 30,
-    temperature: float = None,
-    response_format: Optional[dict] = None,
-) -> str:
+    temperature: Optional[float] = None,
+    tool: Optional[dict] = None,
+) -> Union[str, dict, None]:
     """
-    Ask the OpenAI Assistant a question using Responses API.
-    Uses File Search to ground responses in the uploaded PDF.
+    Ask Claude a question grounded in the ACC PDF (attached via Files API).
+
+    System prompt and PDF are both marked with `cache_control: ephemeral`
+    so the ~50K-token prefix is served from cache on every request after
+    the first one in a 5-minute window.
 
     Args:
-        user_msg: The message/prompt to send to the assistant
-        timeout: Maximum seconds to wait for response
-        temperature: Optional temperature for response generation (0.0-2.0)
-        response_format: Optional OpenAI structured-output format dict (e.g. a
-            json_schema spec). When provided, forces the model to return valid
-            JSON matching the schema, eliminating fragile post-hoc parsing.
+        user_msg: The user question / quiz prompt.
+        timeout: Maximum seconds before the SDK raises APITimeoutError.
+        temperature: Optional temperature (Claude accepts 0.0-1.0). Skipped
+            on models that reject it (Opus 4.7).
+        tool: Optional tool spec dict (`name`, `description`, `input_schema`).
+            When provided, Claude is forced to call exactly this tool and the
+            tool's input dict is returned directly — no JSON parsing needed.
+            Returns None if Claude refuses or no tool_use block is emitted.
+
+    Returns:
+        - str: plain-text response when `tool` is None.
+        - dict: parsed tool input when `tool` is provided.
+        - None: when forced tool-use was requested but the model refused.
     """
-    api_logger.debug(f"ask_assistant called: msg_len={len(user_msg)} timeout={timeout} temperature={temperature} structured={response_format is not None}")
+    api_logger.debug(
+        f"ask_assistant called: msg_len={len(user_msg)} timeout={timeout} "
+        f"temperature={temperature} tool={tool['name'] if tool else None}"
+    )
+
+    request_params = {
+        "model": CLAUDE_MODEL,
+        "max_tokens": 4096,
+        # System prompt is cached so the ~5-min window covers a typical
+        # interactive session at near-zero cost.
+        "system": [
+            {
+                "type": "text",
+                "text": ACC_INSTRUCTIONS,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    # PDF goes first in the user message so a cache breakpoint
+                    # on it covers the whole ~50K-token prefix; the varying
+                    # user question lands after the breakpoint.
+                    {
+                        "type": "document",
+                        "source": {"type": "file", "file_id": ACC_FILE_ID},
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                    {"type": "text", "text": user_msg},
+                ],
+            }
+        ],
+        "betas": ANTHROPIC_BETAS,
+    }
+
+    if temperature is not None and model_supports_temperature(CLAUDE_MODEL):
+        request_params["temperature"] = temperature
+
+    if tool is not None:
+        request_params["tools"] = [tool]
+        request_params["tool_choice"] = {"type": "tool", "name": tool["name"]}
+        # Give forced tool-use plenty of room — quiz schemas with N questions
+        # generate a few KB of structured output.
+        request_params["max_tokens"] = 16000
 
     try:
-        # Build request parameters for Responses API
-        request_params = {
-            "model": ASSISTANT_CONFIG["model"],
-            "instructions": ASSISTANT_CONFIG["instructions"],
-            "input": user_msg,
-        }
+        response = await anthropic_client.beta.messages.create(
+            **request_params, timeout=timeout
+        )
 
-        # Add file search tool if vector stores are configured
-        if ASSISTANT_CONFIG["vector_store_ids"]:
-            request_params["tools"] = [
-                {
-                    "type": "file_search",
-                    "vector_store_ids": ASSISTANT_CONFIG["vector_store_ids"]
-                }
-            ]
+        usage = response.usage
+        api_logger.info(
+            f"Response received: id={response.id} stop_reason={response.stop_reason} "
+            f"input={usage.input_tokens} cache_read={usage.cache_read_input_tokens} "
+            f"cache_write={usage.cache_creation_input_tokens} output={usage.output_tokens}"
+        )
 
-        # Add optional parameters if provided. Skip temperature for models
-        # that reject it (reasoning models, gpt-5 family) to avoid 400 errors.
-        if temperature is not None and model_supports_temperature(ASSISTANT_CONFIG.get("model")):
-            request_params["temperature"] = temperature
+        if response.stop_reason == "refusal":
+            api_logger.warning("Claude refused the request")
+            return None if tool is not None else "❌ The AI declined to answer this question."
 
-        # Structured outputs are passed via the Responses-API `text.format` slot.
-        if response_format is not None:
-            request_params["text"] = {"format": response_format}
+        # Forced tool-use path: return the parsed tool input dict.
+        if tool is not None:
+            for block in response.content:
+                if block.type == "tool_use" and block.name == tool["name"]:
+                    return block.input
+            api_logger.warning(f"Forced tool {tool['name']} but no tool_use block in response")
+            return None
 
-        api_logger.debug(f"Creating response with model={ASSISTANT_CONFIG['model']} timeout={timeout}s")
-
-        # Create response using Responses API (non-streaming). The timeout
-        # kwarg is honored by the OpenAI SDK and raises APITimeoutError if
-        # exceeded.
-        response = await oai.responses.create(**request_params, timeout=timeout)
-
-        api_logger.info(f"Response received: id={response.id} status={response.status}")
-
-        # Extract text from message output items. The output list can contain
-        # tool-call items (e.g. file_search_call) before the message, so we
-        # iterate every item rather than indexing [0].
-        chunks = []
-        for output_item in (response.output or []):
-            if getattr(output_item, "type", None) != "message":
-                continue
-            for content in getattr(output_item, "content", None) or []:
-                if getattr(content, "type", None) == "output_text":
-                    # Remove citation markers like 【4:2†source】
-                    text = re.sub(r'【[^】]*】', '', content.text)
-                    chunks.append(text)
-
+        # Plain-text path: concatenate text blocks.
+        chunks = [block.text for block in response.content if block.type == "text"]
         if not chunks:
-            api_logger.warning("No message output content found in response")
+            api_logger.warning("No text content found in response")
             return "No response from assistant."
 
         result = "\n".join(chunks)
@@ -375,11 +375,12 @@ async def ask_assistant(
         return result
 
     except APITimeoutError:
-        api_logger.error(f"OpenAI request timed out after {timeout}s")
-        return "❌ The AI took too long to respond. Please try again in a moment."
+        api_logger.error(f"Anthropic request timed out after {timeout}s")
+        msg = "❌ The AI took too long to respond. Please try again in a moment."
+        return None if tool is not None else msg
     except Exception as e:
         api_logger.error(f"Error asking assistant: {e}", exc_info=True)
-        return f"❌ Error communicating with AI: {str(e)}"
+        return None if tool is not None else f"❌ Error communicating with AI: {str(e)}"
 
 
 def format_time_remaining(end_time: datetime) -> Tuple[int, int]:
@@ -647,11 +648,19 @@ def deduplicate_questions(questions: List[dict]) -> Tuple[List[dict], List[str]]
 # OpenAI Responses-API structured-output spec for quiz generation. The model
 # is forced to return an object with a `questions` array whose items have all
 # required fields (including `topic`, which the dedup logic depends on).
-QUIZ_RESPONSE_FORMAT = {
-    "type": "json_schema",
-    "name": "quiz_questions",
-    "strict": True,
-    "schema": {
+# Forced tool spec for quiz generation. Claude is required to call this tool
+# (via tool_choice), and the parsed dict comes back directly on the tool_use
+# block — no JSON-string parsing, no fence-stripping, no validation against
+# free-form text. The tool's input_schema is the structured-output spec.
+QUIZ_TOOL = {
+    "name": "submit_quiz",
+    "description": (
+        "Submit a set of multiple-choice quiz questions about the attached "
+        "ACC PDF. Every question must have exactly 4 options, a correct "
+        "answer letter, an explanation with a page reference, the page "
+        "number as an integer, and a short hyphenated topic tag."
+    ),
+    "input_schema": {
         "type": "object",
         "additionalProperties": False,
         "properties": {
@@ -677,36 +686,12 @@ QUIZ_RESPONSE_FORMAT = {
 }
 
 
-def parse_quiz_response(reply: str) -> List[dict]:
-    """
-    Parse an assistant reply into a list of raw question dicts.
-    Tolerates legacy ```json fenced responses for safety; structured outputs
-    should already produce a bare JSON object.
-    """
-    reply_clean = reply.strip()
-    if reply_clean.startswith("```json"):
-        reply_clean = reply_clean[7:]
-    elif reply_clean.startswith("```"):
-        reply_clean = reply_clean[3:]
-    if reply_clean.endswith("```"):
-        reply_clean = reply_clean[:-3]
-    reply_clean = reply_clean.strip()
-
-    data = json.loads(reply_clean)
-    # Structured output: {"questions": [...]}. Permissive fallback: bare list.
-    if isinstance(data, dict) and isinstance(data.get("questions"), list):
-        return data["questions"]
-    if isinstance(data, list):
-        return data
-    return []
-
-
 def validate_quiz_questions(items: List[dict]) -> List[dict]:
     """
     Filter to questions with the required shape; normalize the answer letter.
     Returns shallow-copied dicts so the caller's data isn't mutated. Skips
-    any non-dict items defensively, since the bare-array fallback path in
-    parse_quiz_response doesn't enforce element shape.
+    any non-dict items defensively — the tool input_schema enforces shape on
+    Claude's side but the validator is the second line of defense.
     """
     valid = []
     for raw in items:
@@ -724,17 +709,28 @@ def validate_quiz_questions(items: List[dict]) -> List[dict]:
     return valid
 
 
+async def _request_quiz_questions(prompt: str, temperature: float) -> List[dict]:
+    """Single quiz-generation API call. Returns validated questions or []."""
+    result = await ask_assistant(
+        prompt, timeout=45, temperature=temperature, tool=QUIZ_TOOL,
+    )
+    if not isinstance(result, dict) or "questions" not in result:
+        api_logger.warning(f"submit_quiz returned no questions: {type(result).__name__}")
+        return []
+    return validate_quiz_questions(result["questions"])
+
+
 async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optional[List[dict]]:
     """
-    Generate a quiz from the PDF using the Assistant.
-    Uses OpenAI structured outputs to guarantee well-formed JSON with the
-    required topic field, then deduplicates and regenerates for diversity.
-    Returns a list of question dicts or None on failure.
+    Generate a quiz from the PDF using Claude.
+    Forces tool-use against QUIZ_TOOL so the response is a validated dict,
+    then deduplicates and regenerates for diversity. Returns a list of
+    question dicts or None on failure.
     """
     max_regeneration_attempts = 3
 
     prompt = (
-        f"Generate {num_questions} multiple-choice questions based ONLY on the attached PDF.\n\n"
+        f"Generate {num_questions} multiple-choice questions based ONLY on the attached ACC PDF.\n\n"
         "Requirements:\n"
         "- Each question must have exactly 4 options\n"
         "- Provide a brief explanation with a page reference like (p.XX) in `explain`\n"
@@ -743,16 +739,13 @@ async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optiona
         "- Focus on practical knowledge for DCS pilots\n"
         "- Every question must cover a different topic from the others; do not repeat distinctive keywords\n\n"
         + (f"Topic focus: {topic_hint}" if topic_hint else "Cover various topics from the document.")
+        + "\n\nCall the submit_quiz tool with your questions."
     )
 
     api_logger.info(f"Generating quiz: topic_hint='{topic_hint}', num_questions={num_questions}")
-    reply = await ask_assistant(
-        prompt, timeout=45, temperature=0.7, response_format=QUIZ_RESPONSE_FORMAT,
-    )
-    api_logger.debug(f"Assistant raw reply (first 1000 chars): {reply[:1000]}")
 
     try:
-        valid_questions = validate_quiz_questions(parse_quiz_response(reply))
+        valid_questions = await _request_quiz_questions(prompt, temperature=0.7)
 
         if not valid_questions:
             api_logger.warning("No valid questions returned from assistant")
@@ -765,7 +758,7 @@ async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optiona
         )
         api_logger.info(f"Used topics: {used_topics}")
 
-        # Regeneration loop if we don't have enough unique questions
+        # Regeneration loop if we don't have enough unique questions.
         attempt = 0
         while len(unique_questions) < num_questions and attempt < max_regeneration_attempts:
             attempt += 1
@@ -776,36 +769,28 @@ async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optiona
             )
 
             regen_prompt = (
-                f"Generate {needed + 2} additional multiple-choice questions based ONLY on the attached PDF.\n\n"
+                f"Generate {needed + 2} additional multiple-choice questions based ONLY on the attached ACC PDF.\n\n"
                 f"Do NOT repeat any of these topics (already covered): {', '.join(used_topics)}\n\n"
                 "Same requirements as before: 4 options, A/B/C/D answer letter, explanation with page reference, integer page, hyphenated topic tag.\n"
                 "Each new question must have a unique topic tag different from the ones listed above.\n\n"
                 + (f"Topic focus: {topic_hint}" if topic_hint else "Cover various unused topics from the document.")
+                + "\n\nCall the submit_quiz tool with your questions."
             )
 
-            regen_reply = await ask_assistant(
-                regen_prompt, timeout=45, temperature=0.8, response_format=QUIZ_RESPONSE_FORMAT,
-            )
-            api_logger.debug(f"Regeneration reply (first 500 chars): {regen_reply[:500]}")
+            regen_valid = await _request_quiz_questions(regen_prompt, temperature=0.8)
 
-            try:
-                regen_valid = validate_quiz_questions(parse_quiz_response(regen_reply))
-
-                for q in regen_valid:
-                    topic = extract_topic_from_question(q)
-                    is_duplicate = any(
-                        are_questions_similar(q, existing_q, topic, existing_topic)
-                        for existing_q, existing_topic in zip(unique_questions, used_topics)
-                    )
-                    if not is_duplicate:
-                        unique_questions.append(q)
-                        used_topics.append(topic)
-                        api_logger.debug(f"Added new unique question with topic: {topic}")
-                        if len(unique_questions) >= num_questions:
-                            break
-            except json.JSONDecodeError as e:
-                api_logger.error(f"JSON parse error in regeneration attempt {attempt}: {e}")
-                continue
+            for q in regen_valid:
+                topic = extract_topic_from_question(q)
+                is_duplicate = any(
+                    are_questions_similar(q, existing_q, topic, existing_topic)
+                    for existing_q, existing_topic in zip(unique_questions, used_topics)
+                )
+                if not is_duplicate:
+                    unique_questions.append(q)
+                    used_topics.append(topic)
+                    api_logger.debug(f"Added new unique question with topic: {topic}")
+                    if len(unique_questions) >= num_questions:
+                        break
 
         final_count = len(unique_questions)
         api_logger.info(f"Final quiz: {final_count} unique questions (requested: {num_questions})")
@@ -825,10 +810,6 @@ async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optiona
             api_logger.error("Failed to generate any unique questions")
             return None
 
-    except json.JSONDecodeError as e:
-        api_logger.error(f"JSON parse error: {e}")
-        api_logger.error(f"Response was: {reply[:500]}")
-        return None
     except Exception as e:
         api_logger.error(f"Quiz generation error: {e}", exc_info=True)
         return None
@@ -1321,7 +1302,7 @@ async def info_command(interaction: discord.Interaction):
         description="AI-powered Q&A and quiz bot for Air Control Communication",
         color=0x2d5016  # Forest green
     )
-    embed.add_field(name="Model", value=ASSISTANT_CONFIG.get("model", "GPT-4o-mini"), inline=True)
+    embed.add_field(name="Model", value=CLAUDE_MODEL, inline=True)
     embed.add_field(name="Servers", value=str(len(client.guilds)), inline=True)
     embed.add_field(name="Version", value="1.0.0", inline=True)
     embed.add_field(
@@ -1336,31 +1317,27 @@ async def info_command(interaction: discord.Interaction):
         ),
         inline=False
     )
-    embed.set_footer(text="Powered by OpenAI Responses API")
-    
+    embed.set_footer(text="Powered by the Anthropic Claude API")
+
     await interaction.response.send_message(embed=embed)
 
 
 @client.event
 async def on_ready():
     """Called when the bot is ready."""
-    # Initialize assistant configuration from ASSISTANT_ID
-    discord_logger.info("Initializing assistant configuration...")
-    await initialize_assistant_config()
-    
     await tree.sync()
     discord_logger.info("✈️ DarkstarAIC is online!")
     discord_logger.info(f"📚 Connected to {len(client.guilds)} server(s)")
-    discord_logger.info(f"🤖 Using {ASSISTANT_CONFIG['model']} with Responses API")
+    discord_logger.info(f"🤖 Using {CLAUDE_MODEL} via Anthropic Claude API (file_id={ACC_FILE_ID})")
     discord_logger.info(f"Bot user: {client.user.name}#{client.user.discriminator} (ID: {client.user.id})")
-    
+
     # Log guild information
     for guild in client.guilds:
         discord_logger.info(f"  - Guild: {guild.name} (ID: {guild.id}, Members: {guild.member_count})")
-    
+
     print("✈️ DarkstarAIC is online!")
     print(f"📚 Connected to {len(client.guilds)} server(s)")
-    print(f"🤖 Using {ASSISTANT_CONFIG['model']} with Responses API")
+    print(f"🤖 Using {CLAUDE_MODEL} via Anthropic Claude API")
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -61,14 +61,18 @@ QUIZ_STATE = {}
 # System prompt — defines DarkstarAIC's persona and grounding rules. Edit
 # directly to tune tone or refusal behavior; the value is cached prefix so
 # changes invalidate the prompt cache until the new prefix is re-warmed.
-ACC_INSTRUCTIONS = """You are DarkstarAIC, a flight-training assistant for the DCS (Digital Combat Simulator) Air Control Communication (ACC) community.
+ACC_INSTRUCTIONS = """You are DarkstarAIC, an AI assistant for a DCS (Digital Combat Simulator World) flight squadron. You help squadron members learn and practice the concepts, terminology, and application of the Air Control Communication (ACC) multi-Service tactics, techniques, and procedures (MTTP) publication — more commonly known as air intercept control, C2, or AWACS.
 
-Ground every answer in the ACC procedures PDF attached to this conversation.
-
+Grounding rules:
+- Answer only from the ACC PDF attached to this conversation. If the answer is not in the PDF, say exactly: "That information is not available in the ACC documentation."
 - Cite page numbers inline (e.g. "see p. 42") whenever you reference a procedure.
-- If the user's question can't be answered from the PDF, say so plainly rather than guessing.
-- Use precise aviation terminology; do not soften technical detail for readability.
-- For quiz generation: every question must cover a distinct concept, and each distractor must be plausibly close to the correct answer but unambiguously wrong to a knowledgeable reader."""
+- Use proper military aviation terminology. Be concise but thorough, and don't soften technical detail.
+
+When generating quizzes:
+- Build realistic scenarios with proper context that test the knowledge controllers and pilots actually need.
+- Make every question cover a distinct concept — don't repeat the same terminology across questions.
+- Write distractors that are plausible to a novice but unambiguously wrong to someone who knows the material.
+- Always explain the correct answer and include its page reference."""
 
 
 # --- Button Classes for Quiz Interaction ---
@@ -996,7 +1000,10 @@ async def ask_command(interaction: discord.Interaction, question: str):
     
     await interaction.response.defer(thinking=True)
     
-    enhanced_question = f"{question}\n\n(Answer using ONLY information from the attached PDF documentation. Include page numbers when possible. If the answer isn't in the PDF, say so clearly. Your response MUST be less than 2000 characters to fit in a Discord message.)"
+    # Grounding/page-citation/refusal rules live in ACC_INSTRUCTIONS (the
+    # cached system prompt); only the Discord-specific length constraint needs
+    # to ride along per-request.
+    enhanced_question = f"{question}\n\n(Keep your answer under 2000 characters so it fits in a single Discord message.)"
     
     api_logger.debug(f"Sending question to assistant API: '{enhanced_question[:100]}'")
     answer = await ask_assistant(enhanced_question)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 discord.py==2.7.1
-openai==2.38.0
+anthropic>=0.50.0,<2.0
 
 h11==0.16.0

--- a/scripts/upload_pdf.py
+++ b/scripts/upload_pdf.py
@@ -1,0 +1,45 @@
+"""
+One-time helper to upload the ACC reference PDF to Anthropic's Files API.
+
+Usage:
+    pip install anthropic
+    export ANTHROPIC_API_KEY=...
+    python scripts/upload_pdf.py path/to/acc_2024.pdf
+
+Prints the file_id — set as ACC_FILE_ID on Railway. The file persists on
+Anthropic's side until you delete it; re-running creates a duplicate.
+"""
+import sys
+from pathlib import Path
+
+from anthropic import Anthropic
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+
+    pdf_path = Path(sys.argv[1])
+    if not pdf_path.is_file():
+        print(f"ERROR: {pdf_path} is not a file", file=sys.stderr)
+        return 1
+
+    client = Anthropic()  # reads ANTHROPIC_API_KEY from env
+
+    with pdf_path.open("rb") as fh:
+        uploaded = client.beta.files.upload(
+            file=(pdf_path.name, fh, "application/pdf"),
+        )
+
+    print(f"Uploaded {pdf_path.name}")
+    print(f"  file_id:   {uploaded.id}")
+    print(f"  size:      {uploaded.size_bytes:,} bytes")
+    print()
+    print("Set this on Railway:")
+    print(f"  ACC_FILE_ID={uploaded.id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,16 @@
 """
-Test setup. app.py reads DISCORD_TOKEN, OPENAI_API_KEY, and ASSISTANT_ID at
+Test setup. app.py reads DISCORD_TOKEN, ANTHROPIC_API_KEY, and ACC_FILE_ID at
 import time and raises KeyError if any is missing. Populate fake values
 before any test imports the module so the import succeeds without contacting
-Discord or OpenAI (clients are constructed lazily; no requests are made).
+Discord or Anthropic (clients are constructed lazily; no requests are made).
 """
 import os
 import sys
 from pathlib import Path
 
 os.environ.setdefault("DISCORD_TOKEN", "test-discord-token")
-os.environ.setdefault("OPENAI_API_KEY", "test-openai-key")
-os.environ.setdefault("ASSISTANT_ID", "test-assistant-id")
+os.environ.setdefault("ANTHROPIC_API_KEY", "test-anthropic-key")
+os.environ.setdefault("ACC_FILE_ID", "file-test-id")
 
 # Ensure the project root is importable so `import app` works regardless of
 # pytest's invocation directory.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -92,21 +92,19 @@ def test_chunk_mentions_respects_max_chars():
 
 # --- model_supports_temperature ---
 
-def test_temperature_supported_for_gpt_4_family():
-    assert app.model_supports_temperature("gpt-4o-mini")
-    assert app.model_supports_temperature("gpt-4.1")
-    assert app.model_supports_temperature("gpt-4o")
+def test_temperature_supported_for_haiku_and_sonnet():
+    assert app.model_supports_temperature("claude-haiku-4-5")
+    assert app.model_supports_temperature("claude-sonnet-4-6")
 
 
-def test_temperature_rejected_for_reasoning_models():
-    assert not app.model_supports_temperature("o1-mini")
-    assert not app.model_supports_temperature("o3-pro")
-    assert not app.model_supports_temperature("o4-mini")
+def test_temperature_supported_for_opus_4_6():
+    # Opus 4.6 and earlier accept temperature; only Opus 4.7+ rejects it.
+    assert app.model_supports_temperature("claude-opus-4-6")
+    assert app.model_supports_temperature("claude-opus-4-5")
 
 
-def test_temperature_rejected_for_gpt5_family():
-    assert not app.model_supports_temperature("gpt-5")
-    assert not app.model_supports_temperature("gpt-5-turbo")
+def test_temperature_rejected_for_opus_4_7():
+    assert not app.model_supports_temperature("claude-opus-4-7")
 
 
 def test_temperature_default_true_for_unknown_or_none():

--- a/tests/test_quiz_parsing.py
+++ b/tests/test_quiz_parsing.py
@@ -1,7 +1,10 @@
-"""Tests for parse_quiz_response and validate_quiz_questions."""
-import json
-import pytest
+"""
+Tests for validate_quiz_questions.
 
+`parse_quiz_response` is gone — we now use Claude's forced tool-use, which
+returns a parsed dict directly on the tool_use block. validate_quiz_questions
+remains as the second line of defense against malformed tool inputs.
+"""
 import app
 
 
@@ -14,38 +17,6 @@ def _q(q="Q1", answer="A", n_opts=4):
         "page": 1,
         "topic": "test-topic",
     }
-
-
-def test_parse_bare_json_object():
-    reply = json.dumps({"questions": [_q()]})
-    result = app.parse_quiz_response(reply)
-    assert len(result) == 1
-    assert result[0]["q"] == "Q1"
-
-
-def test_parse_json_code_fence():
-    reply = "```json\n" + json.dumps({"questions": [_q("Q2", "B")]}) + "\n```"
-    result = app.parse_quiz_response(reply)
-    assert len(result) == 1
-    assert result[0]["answer"] == "B"
-
-
-def test_parse_plain_code_fence():
-    reply = "```\n" + json.dumps({"questions": [_q()]}) + "\n```"
-    result = app.parse_quiz_response(reply)
-    assert len(result) == 1
-
-
-def test_parse_bare_array_legacy_fallback():
-    """If the model returns a bare array instead of {questions: [...]}, still parse it."""
-    reply = json.dumps([_q()])
-    result = app.parse_quiz_response(reply)
-    assert len(result) == 1
-
-
-def test_parse_invalid_json_raises_json_error():
-    with pytest.raises(json.JSONDecodeError):
-        app.parse_quiz_response("not json at all")
 
 
 def test_validate_keeps_well_formed():
@@ -91,9 +62,9 @@ def test_validate_rejects_non_list_options():
 
 def test_validate_skips_non_dict_items():
     """
-    parse_quiz_response's bare-array fallback doesn't enforce element shape,
-    so validate must defensively skip ints, strings, and other non-dicts
-    rather than raising TypeError on `k in item`.
+    Defensive: even though Claude's input_schema enforces shape, validate
+    still skips ints / strings / Nones rather than raising TypeError on
+    `k in item`.
     """
     items = [_q(), 42, "not a dict", None, [1, 2, 3], _q("Q2")]
     valid = app.validate_quiz_questions(items)
@@ -108,3 +79,21 @@ def test_validate_does_not_mutate_input():
     items = [original]
     app.validate_quiz_questions(items)
     assert original["answer"] == " b "
+
+
+def test_quiz_tool_schema_shape():
+    """
+    Sanity-check the QUIZ_TOOL spec — Claude rejects schemas that violate
+    structured-output constraints (e.g. missing additionalProperties: false).
+    """
+    schema = app.QUIZ_TOOL["input_schema"]
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    question_schema = schema["properties"]["questions"]["items"]
+    assert question_schema["additionalProperties"] is False
+    # Topic + page must be required so the dedup logic can't collapse on
+    # missing topics — see CLAUDE.md → Deduplication.
+    assert set(question_schema["required"]) == {
+        "q", "options", "answer", "explain", "page", "topic"
+    }
+    assert question_schema["properties"]["answer"]["enum"] == ["A", "B", "C", "D"]


### PR DESCRIPTION
Rolling PR for the Anthropic pivot + persistence work. Each batch is one commit so review can happen incrementally.

## Planned batches

- [x] **Batch 1 — Pivot to Anthropic + drop vector store** (this commit, 3dbc32a). Full SDK swap from `AsyncOpenAI` to `AsyncAnthropic`; ACC PDF attached natively via Files API + `file_id` rather than chunked through a vector store; `cache_control: ephemeral` on both the system prompt and the document block so the ~50K-token prefix serves from cache. Forced tool-use against `QUIZ_TOOL` replaces the OpenAI `json_schema` structured-output path — the parsed dict comes back directly on the `tool_use` block, killing fence-stripping + JSON parsing entirely. Drops `ASSISTANT_ID` / `initialize_assistant_config` / `ASSISTANT_CONFIG` and the lingering deprecated `beta.assistants.retrieve` call. New env vars: `ANTHROPIC_API_KEY`, `ACC_FILE_ID`, optional `CLAUDE_MODEL` (defaults to `claude-haiku-4-5`).
- [ ] **Batch 2 — SQLite layer**: `aiosqlite` dependency, `db.py` with schema (quizzes / quiz_questions / quiz_answers tables) + helper functions, in-memory tests using `:memory:`. No behavior change yet.
- [ ] **Batch 3 — Wire SQLite into quiz lifecycle**: persist quiz/questions/answers at lifecycle hooks; rehydrate active quizzes on startup so deploys/OOMs stop wiping in-flight sessions.

## What you need to do before deploying

These are the only steps that block deploy — none of them block CI on this PR.

1. **Upload the PDF to Anthropic** (one-time):
   ```bash
   pip install anthropic
   export ANTHROPIC_API_KEY=...
   python scripts/upload_pdf.py acc_2024.pdf
   ```
   Print the `file_id`, set as `ACC_FILE_ID` on Railway.

2. **Set Railway env vars**:
   - Add `ANTHROPIC_API_KEY`, `ACC_FILE_ID`
   - Optional: `CLAUDE_MODEL=claude-sonnet-4-6` for better quiz quality (~6× the cost)
   - Drop `OPENAI_API_KEY` and `ASSISTANT_ID` once cutover is verified

3. **Review `ACC_INSTRUCTIONS`** in `app.py` — I dropped in a reasonable default that captures the spirit of "PDF-grounded, cite pages, refuse off-topic." Diff it against your current OpenAI assistant's instructions and tune if needed. (To dump your current instructions: `python -c "from openai import OpenAI; print(OpenAI().beta.assistants.retrieve('$ASSISTANT_ID').instructions)"`.)

## Out of scope (follow-up PRs)

- Provider abstraction (`LLMProvider` interface) — wasn't worth the cost when you decided to commit to Anthropic
- Persistent SQLite (coming in batch 2/3)
- Streaming `/ask` responses, spaced-repetition tutor mode, multi-PDF support — left for separate discussion

https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo)_