### PR TITLE
Persist quizzes to SQLite (survive restarts) + rehydrate on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ ENV/
 *.log
 logs/
 .DS_Store
+
+# SQLite quiz-persistence DB (created at runtime; never committed)
+*.db
+*.db-wal
+*.db-shm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ Four environment variables are required and the bot will crash on startup withou
 - `ANTHROPIC_API_KEY` — Anthropic API key
 - `CLAUDE_MODEL` — optional, defaults to `claude-haiku-4-5`. Bump to `claude-sonnet-4-6` for higher-quality quiz generation (~6× the cost).
 - `ACC_DOCUMENT_PATH` — optional, defaults to `acc_document.txt`. The extracted ACC text the bot loads at startup (see "Extracting the PDF" below). Not an env requirement, but the file must exist or the bot runs ungrounded.
+- `DARKSTAR_DB_PATH` — optional, defaults to `darkstar.db`. SQLite file for quiz persistence. **On Railway, point this at a mounted volume** (e.g. `/data/darkstar.db`) or the DB is ephemeral and in-flight quizzes still vanish on redeploy.
 
 ```bash
 pip install -r requirements.txt
@@ -84,13 +85,15 @@ Both the system prompt and the document block are marked `cache_control: {"type"
 
 Verify caching is working by inspecting `usage.cache_read_input_tokens` in the logs — if it's zero across repeated requests, something is invalidating the prefix (likely an interpolated date or user-id into `ACC_INSTRUCTIONS`).
 
-### Quiz state
+### Quiz state + persistence
 
-`QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id`. Each entry holds the question list (shuffled), per-user answers, end time, duration, initiator user ID, and the `auto_end_quiz` task handle.
+`QUIZ_STATE: dict[int, dict]` is a module-level dict keyed by Discord `channel_id` and is the **hot-path source of truth** (button clicks, timers). Each entry holds the question list (shuffled), per-user answers (`{str(user_id): {int position: choice}}`), end time, duration, initiator user ID, the `quiz_id` of its DB row, and the `auto_end_quiz` task handle.
 
-**This is in-memory only.** Any process restart (deploy, Railway OOM, crash) wipes all in-flight quizzes with no recovery. Only one quiz per channel at a time. Persisting this is the next planned change.
+`db.py` (`QuizStore`, aiosqlite) **mirrors** this to SQLite so quizzes survive a restart. Persistence is **best-effort**: `quiz_start` persists on creation (`create_quiz`), the answer paths call `_persist_answer`, and `display_quiz_results` calls `_persist_completion` — every one wrapped so a storage failure degrades to in-memory-only rather than breaking a live quiz (`quiz_id` stays `None` and the mirror calls no-op). Schema: `quizzes` (surrogate id, `status` active/completed, partial unique index enforcing one *active* quiz per channel), `quiz_questions`, `quiz_answers` (upsert PK). See `tests/test_db.py`.
 
-`auto_end_quiz` is scheduled via `asyncio.create_task(...)` at quiz start; the task handle is stored in `state["end_task"]` to keep it from being GC'd and so `display_quiz_results` can cancel it on manual `/quiz_end`. The cancel path skips itself when invoked from inside the auto-end task to avoid `CancelledError` on self.
+On startup, `on_ready` opens the store **once** (guarded by `_startup_done`) and calls `rehydrate_quizzes`: each active quiz is restored into `QUIZ_STATE` and its `auto_end_quiz` timer re-armed for the *remaining* time; a quiz that expired during downtime is finalized immediately. **Caveat:** buttons on messages posted before a restart won't respond (their `View` objects died with the process) — `/quiz_answer` is the fallback, and recorded answers are preserved regardless. Re-registering persistent views would need channel-scoped `custom_id`s (a follow-up).
+
+`auto_end_quiz` derives its sleep from `state["end_time"]` (not a fixed duration), so both fresh and rehydrated quizzes end at the right wall-clock time. Its task handle is stored in `state["end_task"]` to keep it from being GC'd and so `display_quiz_results` can cancel it on manual `/quiz_end`; the cancel path skips itself when invoked from inside the auto-end task to avoid `CancelledError` on self.
 
 ### Quiz generation pipeline
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app.py .
+COPY app.py db.py ./
 # The extracted ACC documentation the bot loads at startup. Generate with
 # scripts/extract_pdf.py and commit it — the build (and a working bot)
 # requires it.

--- a/app.py
+++ b/app.py
@@ -16,6 +16,8 @@ import discord
 from discord import app_commands
 from anthropic import AsyncAnthropic, APITimeoutError, RateLimitError
 
+import db
+
 # Environment variables
 DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
 ANTHROPIC_API_KEY = os.environ["ANTHROPIC_API_KEY"]
@@ -27,6 +29,9 @@ CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-haiku-4-5")
 # (not a Files-API document block) to avoid the per-page image tokens that
 # pushed a single request past the Tier 1 50K-input-token-per-minute limit.
 ACC_DOCUMENT_PATH = os.environ.get("ACC_DOCUMENT_PATH", "acc_document.txt")
+# SQLite file for quiz persistence. On Railway, point this at a mounted
+# volume (e.g. /data/darkstar.db) so in-flight quizzes survive deploys.
+DARKSTAR_DB_PATH = os.environ.get("DARKSTAR_DB_PATH", "darkstar.db")
 
 # --- Discord client setup ---
 intents = discord.Intents.default()
@@ -54,8 +59,16 @@ discord_logger = logging.getLogger('discord_bot')
 quiz_logger = logging.getLogger('quiz')
 api_logger = logging.getLogger('anthropic_api')
 
-# In-memory quiz state (per-channel)
+# In-memory quiz state (per-channel). The source of truth for the hot path
+# (button clicks, timers); the QuizStore below mirrors it to SQLite so it
+# survives restarts.
 QUIZ_STATE = {}
+
+# Quiz persistence store, opened once in on_ready. Persistence is best-effort:
+# every DB call is wrapped so a storage failure degrades to in-memory-only
+# behavior rather than breaking a live quiz. None until startup completes.
+quiz_store: "db.QuizStore | None" = None
+_startup_done = False
 
 # System prompt — defines DarkstarAIC's persona and grounding rules. Edit
 # directly to tune tone or refusal behavior; the value is cached prefix so
@@ -135,10 +148,11 @@ class QuizAnswerButton(discord.ui.Button):
             state["user_answers"][user_id] = {}
             quiz_logger.debug(f"Initialized answer dict for user {interaction.user.name}({user_id}) in channel {interaction.channel_id}")
         
-        # Store the answer
+        # Store the answer (memory is the hot-path source of truth; mirror to DB)
         state["user_answers"][user_id][self.question_idx] = self.choice
+        await _persist_answer(state, self.question_idx, interaction.user.id, self.choice)
         quiz_logger.info(f"Stored answer: user={interaction.user.name}({user_id}) channel={interaction.channel_id} q={self.question_idx+1} answer={self.choice}")
-        
+
         # Calculate how many questions they've answered
         answered_count = len(state["user_answers"][user_id])
         total_questions = len(state["questions"])
@@ -843,20 +857,56 @@ async def generate_quiz(topic_hint: str = "", num_questions: int = 6) -> Optiona
         return None
 
 
-async def auto_end_quiz(channel_id: int, channel, duration_minutes: int):
-    """Automatically end the quiz after the specified duration."""
-    quiz_logger.info(f"Auto-end task started for channel {channel_id}, will end in {duration_minutes} minutes")
-    
+async def _persist_answer(state: dict, position: int, user_id: int, choice: str) -> None:
+    """Best-effort mirror of an answer to SQLite. Never breaks the live quiz."""
+    quiz_id = state.get("quiz_id")
+    if quiz_store is None or quiz_id is None:
+        return
     try:
-        await asyncio.sleep(duration_minutes * 60)
+        await quiz_store.record_answer(
+            quiz_id=quiz_id,
+            position=position,
+            user_id=user_id,
+            choice=choice,
+            answered_at=datetime.now(timezone.utc),
+        )
+    except Exception as e:
+        quiz_logger.error(f"Failed to persist answer (quiz_id={quiz_id}): {e}", exc_info=True)
 
-        # Check if quiz still exists
-        state = QUIZ_STATE.get(channel_id)
-        if not state:
+
+async def _persist_completion(state: dict) -> None:
+    """Best-effort mark-quiz-completed in SQLite."""
+    quiz_id = state.get("quiz_id")
+    if quiz_store is None or quiz_id is None:
+        return
+    try:
+        await quiz_store.complete_quiz(quiz_id)
+    except Exception as e:
+        quiz_logger.error(f"Failed to mark quiz completed (quiz_id={quiz_id}): {e}", exc_info=True)
+
+
+async def auto_end_quiz(channel_id: int, channel):
+    """
+    End the quiz when its stored end_time arrives. Sleeps the remaining time
+    derived from state["end_time"] (rather than a fixed duration) so a quiz
+    rehydrated after a restart resumes with the correct remaining window.
+    """
+    state = QUIZ_STATE.get(channel_id)
+    if not state:
+        return
+    remaining = (state["end_time"] - datetime.now(timezone.utc)).total_seconds()
+    quiz_logger.info(f"Auto-end task started for channel {channel_id}, ending in {remaining:.0f}s")
+
+    try:
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+
+        # Check if quiz still exists (manual /quiz_end may have ended it)
+        if not QUIZ_STATE.get(channel_id):
             quiz_logger.warning(f"Auto-end: quiz no longer exists in channel {channel_id}")
             return
 
-        quiz_logger.info(f"Auto-ending quiz in channel {channel_id} after {duration_minutes} minutes")
+        quiz_logger.info(f"Auto-ending quiz in channel {channel_id}")
 
         # Calculate and display results
         await display_quiz_results(channel, channel_id)
@@ -1002,8 +1052,9 @@ async def display_quiz_results(channel, channel_id: int):
     
     # Send closing message
     await channel.send("Start a new quiz with `/quiz_start`!")
-    
-    # Clean up state
+
+    # Mark completed in the DB (keeps the row for history) then clean up memory.
+    await _persist_completion(state)
     QUIZ_STATE.pop(channel_id, None)
     quiz_logger.info(f"Cleaned up quiz state for channel {channel_id}")
 
@@ -1097,25 +1148,46 @@ async def quiz_start(interaction: discord.Interaction, topic: str = "", question
     
     # Shuffle the options for each question to randomize correct answer position
     shuffled_questions = [shuffle_quiz_options(q) for q in quiz_questions]
-    
-    end_time = datetime.now(timezone.utc) + timedelta(minutes=duration)
-    
+
+    started_at = datetime.now(timezone.utc)
+    end_time = started_at + timedelta(minutes=duration)
+
+    # Persist the quiz before going live so it survives a restart. Best-effort:
+    # if the store is down, the quiz still runs in memory (quiz_id stays None,
+    # so answer/completion persistence is skipped).
+    quiz_id = None
+    if quiz_store is not None:
+        try:
+            quiz_id = await quiz_store.create_quiz(
+                channel_id=interaction.channel_id,
+                guild_id=interaction.guild_id,
+                initiator_id=interaction.user.id,
+                topic=topic,
+                started_at=started_at,
+                end_time=end_time,
+                duration_minutes=duration,
+                questions=shuffled_questions,
+            )
+        except Exception as e:
+            quiz_logger.error(f"Failed to persist new quiz in channel {interaction.channel_id}: {e}", exc_info=True)
+
     QUIZ_STATE[interaction.channel_id] = {
         "questions": shuffled_questions,
         "user_answers": {},  # {user_id: {question_idx: choice}}
         "end_time": end_time,
         "duration_minutes": duration,
-        "initiator": interaction.user.id
+        "initiator": interaction.user.id,
+        "quiz_id": quiz_id,
     }
-    
-    quiz_logger.info(f"Quiz started in channel {interaction.channel_id} by user {interaction.user.name}({interaction.user.id}): {len(shuffled_questions)} questions, {duration} minutes")
+
+    quiz_logger.info(f"Quiz started in channel {interaction.channel_id} by user {interaction.user.name}({interaction.user.id}): {len(shuffled_questions)} questions, {duration} minutes, quiz_id={quiz_id}")
 
     topic_text = f" (Topic: {topic})" if topic else ""
 
     # Schedule auto-end task and hold a strong reference in QUIZ_STATE so it
     # isn't garbage-collected mid-sleep, and so /quiz_end can cancel it.
     end_task = asyncio.create_task(
-        auto_end_quiz(interaction.channel_id, interaction.channel, duration)
+        auto_end_quiz(interaction.channel_id, interaction.channel)
     )
     QUIZ_STATE[interaction.channel_id]["end_task"] = end_task
     
@@ -1202,8 +1274,9 @@ async def quiz_answer(interaction: discord.Interaction, question_number: int, ch
         state["user_answers"][user_id] = {}
         quiz_logger.debug(f"Initialized answer dict for user {interaction.user.name}({user_id}) in channel {interaction.channel_id}")
     
-    # Store the answer
+    # Store the answer (memory is the hot-path source of truth; mirror to DB)
     state["user_answers"][user_id][question_idx] = choice
+    await _persist_answer(state, question_idx, interaction.user.id, choice)
     quiz_logger.info(f"Stored answer via command: user={interaction.user.name}({user_id}) channel={interaction.channel_id} q={question_number} answer={choice}")
     
     # Calculate how many questions they've answered
@@ -1353,9 +1426,81 @@ async def info_command(interaction: discord.Interaction):
     await interaction.response.send_message(embed=embed)
 
 
+async def _resolve_channel(channel_id: int):
+    """Get a channel object from cache, falling back to a fetch."""
+    channel = client.get_channel(channel_id)
+    if channel is not None:
+        return channel
+    try:
+        return await client.fetch_channel(channel_id)
+    except Exception:
+        return None
+
+
+async def rehydrate_quizzes():
+    """
+    Restore active quizzes from SQLite into QUIZ_STATE after a restart.
+
+    Each restored quiz re-arms its auto-end timer for the *remaining* time
+    (auto_end_quiz derives the sleep from end_time). A quiz whose end_time
+    passed during downtime is finalized immediately. Note: the buttons on
+    messages posted before the restart won't respond (their View objects died
+    with the process) — `/quiz_answer` is the fallback, and recorded answers
+    are preserved either way.
+    """
+    if quiz_store is None:
+        return
+    try:
+        active = await quiz_store.load_active_quizzes()
+    except Exception as e:
+        quiz_logger.error(f"Failed to load active quizzes for rehydration: {e}", exc_info=True)
+        return
+
+    quiz_logger.info(f"Rehydrating {len(active)} active quiz(es) from {DARKSTAR_DB_PATH}")
+    for q in active:
+        channel_id = q["channel_id"]
+        if channel_id in QUIZ_STATE:
+            continue  # already live (defensive; shouldn't happen on a fresh start)
+
+        state = {
+            "questions": q["questions"],
+            # DB returns answers keyed by int user_id; the in-memory format
+            # keys by str(user_id) with int question positions.
+            "user_answers": {str(uid): dict(pos) for uid, pos in q["answers"].items()},
+            "end_time": q["end_time"],
+            "duration_minutes": q["duration_minutes"],
+            "initiator": q["initiator_id"],
+            "quiz_id": q["quiz_id"],
+        }
+        QUIZ_STATE[channel_id] = state
+
+        channel = await _resolve_channel(channel_id)
+        if channel is None:
+            quiz_logger.warning(
+                f"Rehydrate: channel {channel_id} unreachable; completing quiz {q['quiz_id']}"
+            )
+            await _persist_completion(state)
+            QUIZ_STATE.pop(channel_id, None)
+            continue
+
+        remaining = (q["end_time"] - datetime.now(timezone.utc)).total_seconds()
+        if remaining > 0:
+            task = asyncio.create_task(auto_end_quiz(channel_id, channel))
+            state["end_task"] = task
+            quiz_logger.info(
+                f"Rehydrated quiz {q['quiz_id']} in channel {channel_id}, {remaining:.0f}s remaining"
+            )
+        else:
+            quiz_logger.info(
+                f"Rehydrated quiz {q['quiz_id']} in channel {channel_id} expired during downtime; finalizing"
+            )
+            await display_quiz_results(channel, channel_id)
+
+
 @client.event
 async def on_ready():
     """Called when the bot is ready."""
+    global quiz_store, _startup_done
     await tree.sync()
     discord_logger.info("✈️ DarkstarAIC is online!")
     discord_logger.info(f"📚 Connected to {len(client.guilds)} server(s)")
@@ -1373,6 +1518,22 @@ async def on_ready():
     # Log guild information
     for guild in client.guilds:
         discord_logger.info(f"  - Guild: {guild.name} (ID: {guild.id}, Members: {guild.member_count})")
+
+    # Open the quiz store and restore in-flight quizzes — once, even if
+    # on_ready fires again on a gateway reconnect.
+    if not _startup_done:
+        _startup_done = True
+        try:
+            quiz_store = await db.QuizStore.connect(DARKSTAR_DB_PATH)
+            discord_logger.info(f"🗄️  Quiz store opened at {DARKSTAR_DB_PATH}")
+        except Exception as e:
+            discord_logger.error(
+                f"Failed to open quiz store at {DARKSTAR_DB_PATH}: {e} — "
+                f"running in-memory only (quizzes won't survive restarts)",
+                exc_info=True,
+            )
+            quiz_store = None
+        await rehydrate_quizzes()
 
     print("✈️ DarkstarAIC is online!")
     print(f"📚 Connected to {len(client.guilds)} server(s)")

--- a/db.py
+++ b/db.py
@@ -1,0 +1,231 @@
+"""
+SQLite persistence for quiz state, backed by aiosqlite.
+
+Quizzes are stored so an in-flight quiz survives a process restart (deploy,
+Railway OOM, crash) and so completed quizzes accumulate as history for future
+per-user stats. The schema keeps every quiz (surrogate `id` key) and marks it
+`active` or `completed`; a partial unique index enforces the bot's invariant
+of at most one *active* quiz per channel while leaving completed rows for
+history.
+
+The store is decoupled from the bot's in-memory QUIZ_STATE shape: it returns
+naturalized rows (datetimes parsed, options as lists, answers nested by int
+user_id), and app.py maps those onto its runtime dict.
+"""
+import json
+from datetime import datetime
+from typing import List, Optional
+
+import aiosqlite
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS quizzes (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel_id       INTEGER NOT NULL,
+    guild_id         INTEGER,
+    initiator_id     INTEGER NOT NULL,
+    topic            TEXT,
+    started_at       TEXT NOT NULL,
+    end_time         TEXT NOT NULL,
+    duration_minutes INTEGER NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'active'
+);
+
+-- At most one active quiz per channel; completed quizzes are unconstrained
+-- so history accumulates and a channel can start a new quiz after one ends.
+CREATE UNIQUE INDEX IF NOT EXISTS one_active_quiz_per_channel
+    ON quizzes (channel_id) WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS quiz_questions (
+    quiz_id      INTEGER NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+    position     INTEGER NOT NULL,
+    question     TEXT NOT NULL,
+    options_json TEXT NOT NULL,
+    answer       TEXT NOT NULL,
+    explain      TEXT NOT NULL,
+    topic        TEXT,
+    page         INTEGER,
+    PRIMARY KEY (quiz_id, position)
+);
+
+CREATE TABLE IF NOT EXISTS quiz_answers (
+    quiz_id      INTEGER NOT NULL REFERENCES quizzes(id) ON DELETE CASCADE,
+    position     INTEGER NOT NULL,
+    user_id      INTEGER NOT NULL,
+    choice       TEXT NOT NULL,
+    answered_at  TEXT NOT NULL,
+    PRIMARY KEY (quiz_id, position, user_id)
+);
+"""
+
+
+class QuizStore:
+    """Async wrapper around the quiz persistence tables."""
+
+    def __init__(self, conn: aiosqlite.Connection):
+        self._conn = conn
+
+    @classmethod
+    async def connect(cls, path: str) -> "QuizStore":
+        conn = await aiosqlite.connect(path)
+        conn.row_factory = aiosqlite.Row
+        # WAL improves concurrent read/write behavior; foreign_keys must be
+        # enabled per-connection for the ON DELETE CASCADE to fire.
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA foreign_keys=ON")
+        await conn.executescript(_SCHEMA)
+        await conn.commit()
+        return cls(conn)
+
+    async def close(self) -> None:
+        await self._conn.close()
+
+    async def create_quiz(
+        self,
+        *,
+        channel_id: int,
+        guild_id: Optional[int],
+        initiator_id: int,
+        topic: str,
+        started_at: datetime,
+        end_time: datetime,
+        duration_minutes: int,
+        questions: List[dict],
+    ) -> int:
+        """
+        Insert a new active quiz and its (shuffled) questions in one
+        transaction. `questions` are stored in list order as positions 0..N-1.
+        Returns the new quiz id. Raises if the channel already has an active
+        quiz (enforced by the partial unique index).
+        """
+        cur = await self._conn.execute(
+            """
+            INSERT INTO quizzes
+                (channel_id, guild_id, initiator_id, topic, started_at,
+                 end_time, duration_minutes, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'active')
+            """,
+            (
+                channel_id,
+                guild_id,
+                initiator_id,
+                topic,
+                started_at.isoformat(),
+                end_time.isoformat(),
+                duration_minutes,
+            ),
+        )
+        quiz_id = cur.lastrowid
+        await self._conn.executemany(
+            """
+            INSERT INTO quiz_questions
+                (quiz_id, position, question, options_json, answer, explain, topic, page)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    quiz_id,
+                    position,
+                    q["q"],
+                    json.dumps(q["options"]),
+                    q["answer"],
+                    q["explain"],
+                    q.get("topic"),
+                    q.get("page"),
+                )
+                for position, q in enumerate(questions)
+            ],
+        )
+        await self._conn.commit()
+        return quiz_id
+
+    async def record_answer(
+        self,
+        *,
+        quiz_id: int,
+        position: int,
+        user_id: int,
+        choice: str,
+        answered_at: datetime,
+    ) -> None:
+        """Upsert a user's answer to one question (re-answering overwrites)."""
+        await self._conn.execute(
+            """
+            INSERT INTO quiz_answers (quiz_id, position, user_id, choice, answered_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT (quiz_id, position, user_id)
+            DO UPDATE SET choice = excluded.choice, answered_at = excluded.answered_at
+            """,
+            (quiz_id, position, user_id, choice, answered_at.isoformat()),
+        )
+        await self._conn.commit()
+
+    async def complete_quiz(self, quiz_id: int) -> None:
+        """Mark a quiz completed so it no longer counts as active."""
+        await self._conn.execute(
+            "UPDATE quizzes SET status = 'completed' WHERE id = ?", (quiz_id,)
+        )
+        await self._conn.commit()
+
+    async def load_active_quizzes(self) -> List[dict]:
+        """
+        Return all active quizzes with their questions and recorded answers,
+        for rehydrating QUIZ_STATE on startup. Each dict:
+
+            {
+              quiz_id, channel_id, guild_id, initiator_id, topic,
+              started_at: datetime, end_time: datetime, duration_minutes,
+              questions: [{q, options, answer, explain, topic, page}, ...],  # by position
+              answers: {user_id(int): {position(int): choice}},
+            }
+        """
+        quiz_rows = await self._fetchall(
+            "SELECT * FROM quizzes WHERE status = 'active'"
+        )
+        result = []
+        for qr in quiz_rows:
+            quiz_id = qr["id"]
+            question_rows = await self._fetchall(
+                "SELECT * FROM quiz_questions WHERE quiz_id = ? ORDER BY position",
+                (quiz_id,),
+            )
+            questions = [
+                {
+                    "q": r["question"],
+                    "options": json.loads(r["options_json"]),
+                    "answer": r["answer"],
+                    "explain": r["explain"],
+                    "topic": r["topic"],
+                    "page": r["page"],
+                }
+                for r in question_rows
+            ]
+            answer_rows = await self._fetchall(
+                "SELECT position, user_id, choice FROM quiz_answers WHERE quiz_id = ?",
+                (quiz_id,),
+            )
+            answers: dict = {}
+            for r in answer_rows:
+                answers.setdefault(r["user_id"], {})[r["position"]] = r["choice"]
+
+            result.append(
+                {
+                    "quiz_id": quiz_id,
+                    "channel_id": qr["channel_id"],
+                    "guild_id": qr["guild_id"],
+                    "initiator_id": qr["initiator_id"],
+                    "topic": qr["topic"],
+                    "started_at": datetime.fromisoformat(qr["started_at"]),
+                    "end_time": datetime.fromisoformat(qr["end_time"]),
+                    "duration_minutes": qr["duration_minutes"],
+                    "questions": questions,
+                    "answers": answers,
+                }
+            )
+        return result
+
+    async def _fetchall(self, sql: str, params: tuple = ()) -> List[aiosqlite.Row]:
+        cur = await self._conn.execute(sql, params)
+        rows = await cur.fetchall()
+        await cur.close()
+        return rows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,5 @@ select = ["F", "E9", "W6"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra"
+# Async DB tests use plain `async def` without per-test markers.
+asyncio_mode = "auto"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest>=8.0
+pytest-asyncio>=0.23
 ruff>=0.6
 # Used only by scripts/extract_pdf.py (local, one-time); not a runtime dep.
 pypdf>=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 discord.py==2.7.1
 anthropic>=0.50.0,<2.0
+aiosqlite>=0.20.0
 
 h11==0.16.0

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,130 @@
+"""Tests for the QuizStore persistence layer, run against an in-memory DB."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+
+import db
+
+
+def _questions(n=3):
+    return [
+        {
+            "q": f"Question {i}?",
+            "options": ["a", "b", "c", "d"],
+            "answer": "A",
+            "explain": f"explanation {i}",
+            "topic": f"topic-{i}",
+            "page": i + 1,
+        }
+        for i in range(n)
+    ]
+
+
+def _quiz_kwargs(channel_id=100, **overrides):
+    now = datetime.now(timezone.utc)
+    base = {
+        "channel_id": channel_id,
+        "guild_id": 200,
+        "initiator_id": 300,
+        "topic": "radio-procedures",
+        "started_at": now,
+        "end_time": now + timedelta(minutes=15),
+        "duration_minutes": 15,
+        "questions": _questions(),
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest_asyncio.fixture
+async def store():
+    s = await db.QuizStore.connect(":memory:")
+    yield s
+    await s.close()
+
+
+async def test_create_quiz_returns_id_and_loads_active(store):
+    quiz_id = await store.create_quiz(**_quiz_kwargs())
+    assert isinstance(quiz_id, int)
+
+    active = await store.load_active_quizzes()
+    assert len(active) == 1
+    q = active[0]
+    assert q["quiz_id"] == quiz_id
+    assert q["channel_id"] == 100
+    assert q["guild_id"] == 200
+    assert q["initiator_id"] == 300
+    assert q["topic"] == "radio-procedures"
+    assert q["duration_minutes"] == 15
+    assert len(q["questions"]) == 3
+    assert q["answers"] == {}
+
+
+async def test_questions_roundtrip_in_order_with_options(store):
+    await store.create_quiz(**_quiz_kwargs())
+    q = (await store.load_active_quizzes())[0]
+    # Order preserved by position
+    assert [item["q"] for item in q["questions"]] == ["Question 0?", "Question 1?", "Question 2?"]
+    # Options deserialized back to a list
+    assert q["questions"][0]["options"] == ["a", "b", "c", "d"]
+    assert q["questions"][2]["page"] == 3
+
+
+async def test_datetimes_roundtrip_as_aware(store):
+    kwargs = _quiz_kwargs()
+    await store.create_quiz(**kwargs)
+    q = (await store.load_active_quizzes())[0]
+    assert q["end_time"] == kwargs["end_time"]
+    assert q["end_time"].tzinfo is not None
+
+
+async def test_record_answer_and_load(store):
+    quiz_id = await store.create_quiz(**_quiz_kwargs())
+    now = datetime.now(timezone.utc)
+    await store.record_answer(quiz_id=quiz_id, position=0, user_id=42, choice="B", answered_at=now)
+    await store.record_answer(quiz_id=quiz_id, position=1, user_id=42, choice="C", answered_at=now)
+    await store.record_answer(quiz_id=quiz_id, position=0, user_id=99, choice="A", answered_at=now)
+
+    answers = (await store.load_active_quizzes())[0]["answers"]
+    assert answers == {42: {0: "B", 1: "C"}, 99: {0: "A"}}
+
+
+async def test_record_answer_overwrites(store):
+    quiz_id = await store.create_quiz(**_quiz_kwargs())
+    now = datetime.now(timezone.utc)
+    await store.record_answer(quiz_id=quiz_id, position=0, user_id=42, choice="A", answered_at=now)
+    await store.record_answer(quiz_id=quiz_id, position=0, user_id=42, choice="D", answered_at=now)
+
+    answers = (await store.load_active_quizzes())[0]["answers"]
+    assert answers == {42: {0: "D"}}
+
+
+async def test_complete_quiz_excluded_from_active(store):
+    quiz_id = await store.create_quiz(**_quiz_kwargs())
+    await store.complete_quiz(quiz_id)
+    assert await store.load_active_quizzes() == []
+
+
+async def test_one_active_quiz_per_channel_enforced(store):
+    await store.create_quiz(**_quiz_kwargs(channel_id=100))
+    with pytest.raises(Exception):
+        await store.create_quiz(**_quiz_kwargs(channel_id=100))
+
+
+async def test_channel_can_start_new_quiz_after_completion(store):
+    first = await store.create_quiz(**_quiz_kwargs(channel_id=100))
+    await store.complete_quiz(first)
+    # Same channel, new quiz — should succeed now that the first is completed.
+    second = await store.create_quiz(**_quiz_kwargs(channel_id=100))
+    assert second != first
+    active = await store.load_active_quizzes()
+    assert len(active) == 1
+    assert active[0]["quiz_id"] == second
+
+
+async def test_multiple_channels_independent(store):
+    await store.create_quiz(**_quiz_kwargs(channel_id=1))
+    await store.create_quiz(**_quiz_kwargs(channel_id=2))
+    active = await store.load_active_quizzes()
+    assert {q["channel_id"] for q in active} == {1, 2}


### PR DESCRIPTION
Persists quiz state to SQLite so a process restart (deploy, Railway OOM, crash) no longer wipes in-flight quizzes — and lays the groundwork for per-user stats/history.

## Batch 2 — `db.py` storage layer (commit 1)

`aiosqlite`-backed `QuizStore`, no app wiring yet:
- **Schema**: `quizzes` (surrogate id, `status` active/completed, **partial unique index** enforcing one *active* quiz per channel while keeping completed rows for history), `quiz_questions` (options as JSON, by position), `quiz_answers` (`(quiz_id, position, user_id)` PK, upsert so re-answering overwrites).
- **API**: `connect` (WAL + foreign_keys + schema), `create_quiz`, `record_answer`, `complete_quiz`, `load_active_quizzes` (returns naturalized rows — datetimes parsed, options as lists, answers nested by int user_id).
- **9 tests** against an in-memory DB: roundtrip, ordering, tz-aware datetimes, answer upsert, completion, the per-channel uniqueness constraint, post-completion reuse.

## Batch 3 — wire it into the lifecycle (commit 2)

- `quiz_start` persists on creation, stores `quiz_id` in `QUIZ_STATE`.
- Both answer paths (button + `/quiz_answer`) mirror to SQLite.
- `display_quiz_results` marks the quiz completed before clearing memory.
- `on_ready` opens the store **once** and `rehydrate_quizzes` restores active quizzes — re-arming each auto-end timer for the *remaining* time, finalizing any that expired during downtime. `auto_end_quiz` now derives its sleep from `end_time` so fresh and rehydrated quizzes both end correctly.

**All persistence is best-effort** — every DB call is wrapped so a storage failure (or unopened store) degrades to in-memory-only rather than breaking a live quiz.

## Known limitation

Buttons on messages posted **before** a restart won't respond (their `View` objects died with the process). `/quiz_answer` is the fallback and recorded answers are preserved either way. Re-registering persistent views needs channel-scoped `custom_id`s — noted as a follow-up.

## ⚠️ Deploy requirement

`DARKSTAR_DB_PATH` defaults to `darkstar.db` in the working dir, which is **ephemeral on Railway**. To actually survive redeploys, **mount a Railway volume and set `DARKSTAR_DB_PATH=/data/darkstar.db`** (or wherever you mount it). Without that, the DB is recreated empty on each deploy and quizzes still vanish — the code works, but the persistence is pointless.

## Testing notes

Data layer is covered by `tests/test_db.py` (48 tests total, ruff clean). The **Discord runtime wiring** — `on_ready` rehydration, channel resolution, timer re-arming — can only be verified with a live bot; I couldn't exercise that here. Suggested manual check: start a quiz, answer a question, restart the bot, confirm the log shows `Rehydrated quiz ...` and the timer still fires with results.

https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo)_