### PR TITLE
Add /quiz_stats for lifetime per-user quiz stats

### DIFF
--- a/app.py
+++ b/app.py
@@ -1527,6 +1527,52 @@ async def quiz_score(interaction: discord.Interaction):
     )
 
 
+@tree.command(name="quiz_stats", description="Show your lifetime quiz stats across completed quizzes")
+async def quiz_stats(interaction: discord.Interaction):
+    """Show the calling user's aggregate performance from quiz history."""
+    discord_logger.info(f"/quiz_stats command: user={interaction.user.name}({interaction.user.id}) guild={interaction.guild.name if interaction.guild else 'DM'}({interaction.guild_id if interaction.guild else 'N/A'}) channel={interaction.channel_id}")
+
+    has_perms, perm_error = await check_bot_permissions(interaction)
+    if not has_perms:
+        await interaction.response.send_message(perm_error, ephemeral=True)
+        return
+
+    # Stats live in the persistence layer; if it's down there's nothing to show.
+    if quiz_store is None:
+        await interaction.response.send_message(
+            "❌ Quiz history isn't available right now (persistence is offline).",
+            ephemeral=True,
+        )
+        return
+
+    try:
+        stats = await quiz_store.get_user_stats(interaction.user.id)
+    except Exception as e:
+        quiz_logger.error(f"Failed to load stats for user {interaction.user.id}: {e}", exc_info=True)
+        await interaction.response.send_message(
+            "❌ Couldn't load your stats right now. Try again in a moment.",
+            ephemeral=True,
+        )
+        return
+
+    if stats["answered"] == 0:
+        await interaction.response.send_message(
+            "📊 You haven't answered any questions in a completed quiz yet — "
+            "jump into a `/quiz_start`!",
+            ephemeral=True,
+        )
+        return
+
+    accuracy_pct = round(stats["accuracy"] * 100)
+    embed = discord.Embed(title="📊 Your Quiz Stats", color=0x2d5016)
+    embed.add_field(name="Quizzes", value=str(stats["quizzes"]), inline=True)
+    embed.add_field(name="Questions Answered", value=str(stats["answered"]), inline=True)
+    embed.add_field(name="Correct", value=f"{stats['correct']} ({accuracy_pct}%)", inline=True)
+    embed.set_footer(text="Across completed quizzes")
+
+    await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
 @tree.command(name="info", description="Show bot information and stats")
 async def info_command(interaction: discord.Interaction):
     """Display bot information."""
@@ -1553,6 +1599,7 @@ async def info_command(interaction: discord.Interaction):
             "• `/quiz_start` - Start a timed quiz (1-60 min, 1-10 questions)\n"
             "• `/quiz_answer` - Submit an answer by question number (alternative to buttons)\n"
             "• `/quiz_score` - View your progress in the running quiz\n"
+            "• `/quiz_stats` - View your lifetime quiz stats\n"
             "• `/quiz_end` - End the running quiz (initiator/mod only)\n"
             "• `/info` - Show this info panel"
         ),

--- a/db.py
+++ b/db.py
@@ -224,8 +224,46 @@ class QuizStore:
             )
         return result
 
+    async def get_user_stats(self, user_id: int) -> dict:
+        """
+        Aggregate a user's answers across **completed** quizzes (active quizzes
+        are excluded so the numbers don't move mid-quiz). Correctness compares
+        the recorded choice to the shuffled answer stored for that question.
+
+        Returns {quizzes, answered, correct, accuracy}, where accuracy is a
+        float 0.0-1.0 (0.0 when the user has answered nothing).
+        """
+        row = await self._fetchone(
+            """
+            SELECT
+                COUNT(DISTINCT a.quiz_id) AS quizzes,
+                COUNT(*) AS answered,
+                COALESCE(SUM(CASE WHEN a.choice = q.answer THEN 1 ELSE 0 END), 0) AS correct
+            FROM quiz_answers a
+            JOIN quizzes z ON z.id = a.quiz_id AND z.status = 'completed'
+            JOIN quiz_questions q ON q.quiz_id = a.quiz_id AND q.position = a.position
+            WHERE a.user_id = ?
+            """,
+            (user_id,),
+        )
+        answered = (row["answered"] if row else 0) or 0
+        correct = (row["correct"] if row else 0) or 0
+        quizzes = (row["quizzes"] if row else 0) or 0
+        return {
+            "quizzes": quizzes,
+            "answered": answered,
+            "correct": correct,
+            "accuracy": (correct / answered) if answered else 0.0,
+        }
+
     async def _fetchall(self, sql: str, params: tuple = ()) -> List[aiosqlite.Row]:
         cur = await self._conn.execute(sql, params)
         rows = await cur.fetchall()
         await cur.close()
         return rows
+
+    async def _fetchone(self, sql: str, params: tuple = ()) -> Optional[aiosqlite.Row]:
+        cur = await self._conn.execute(sql, params)
+        row = await cur.fetchone()
+        await cur.close()
+        return row

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -128,3 +128,51 @@ async def test_multiple_channels_independent(store):
     await store.create_quiz(**_quiz_kwargs(channel_id=2))
     active = await store.load_active_quizzes()
     assert {q["channel_id"] for q in active} == {1, 2}
+
+
+# --- get_user_stats ---
+
+async def test_get_user_stats_counts_correct_and_accuracy(store):
+    now = datetime.now(timezone.utc)
+    # _questions() all have answer "A". Quiz 1: user 42 gets q0 right, q1 wrong.
+    q1 = await store.create_quiz(**_quiz_kwargs(channel_id=1))
+    await store.record_answer(quiz_id=q1, position=0, user_id=42, choice="A", answered_at=now)
+    await store.record_answer(quiz_id=q1, position=1, user_id=42, choice="B", answered_at=now)
+    await store.complete_quiz(q1)
+    # Quiz 2: user 42 gets q0 right.
+    q2 = await store.create_quiz(**_quiz_kwargs(channel_id=2))
+    await store.record_answer(quiz_id=q2, position=0, user_id=42, choice="A", answered_at=now)
+    await store.complete_quiz(q2)
+
+    stats = await store.get_user_stats(42)
+    assert stats["quizzes"] == 2
+    assert stats["answered"] == 3
+    assert stats["correct"] == 2
+    assert stats["accuracy"] == 2 / 3
+
+
+async def test_get_user_stats_excludes_active_quizzes(store):
+    # Answers in an active (not completed) quiz must not count.
+    qid = await store.create_quiz(**_quiz_kwargs(channel_id=1))
+    await store.record_answer(quiz_id=qid, position=0, user_id=42, choice="A", answered_at=datetime.now(timezone.utc))
+    assert await store.get_user_stats(42) == {"quizzes": 0, "answered": 0, "correct": 0, "accuracy": 0.0}
+
+
+async def test_get_user_stats_unknown_user_is_zero(store):
+    qid = await store.create_quiz(**_quiz_kwargs())
+    await store.complete_quiz(qid)
+    stats = await store.get_user_stats(999)
+    assert stats["answered"] == 0
+    assert stats["correct"] == 0
+    assert stats["accuracy"] == 0.0
+
+
+async def test_get_user_stats_is_per_user(store):
+    now = datetime.now(timezone.utc)
+    qid = await store.create_quiz(**_quiz_kwargs())
+    await store.record_answer(quiz_id=qid, position=0, user_id=1, choice="A", answered_at=now)  # correct
+    await store.record_answer(quiz_id=qid, position=0, user_id=2, choice="D", answered_at=now)  # wrong
+    await store.complete_quiz(qid)
+
+    assert (await store.get_user_stats(1))["correct"] == 1
+    assert (await store.get_user_stats(2))["correct"] == 0


### PR DESCRIPTION
## Summary
- Adds `QuizStore.get_user_stats(user_id)` — aggregates a user's answers across **completed** quizzes into `{quizzes, answered, correct, accuracy}`, comparing each recorded choice to the stored (shuffled) answer.
- New `/quiz_stats` slash command surfaces it as an ephemeral embed: quizzes taken, questions answered, and correct count + accuracy %. `/info` now lists the command.
- Active quizzes are excluded so the numbers don't move mid-quiz.

## Notes
- Stats are **global per user** (across servers). Guild-scoping would be a one-line `WHERE` clause if you'd rather have per-server stats — easy to add.
- Degrades gracefully: a friendly message if persistence is offline, and an empty-state nudge if the user has no completed-quiz history yet.
- Reuses the existing `quizzes`/`quiz_questions`/`quiz_answers` schema — no migration. The history this reads has been recorded since the SQLite persistence layer landed.

## Test plan
- [x] `ruff check .` clean
- [x] `pytest` — 70 passing (adds 4 `get_user_stats` tests: correctness/accuracy, active-quiz exclusion, unknown user, per-user isolation)
- [ ] In Discord: `/quiz_stats` shows correct totals after finishing a quiz, and the empty-state message before any history exists

https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9JdoKUiX8vpS2SbZtQRBo)_