### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/joemurrell/darkstar/security/code-scanning/1](https://github.com/joemurrell/darkstar/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: define workflow-level permissions right after the `on:` block (before `jobs:`), with `contents: read`. This applies to all jobs in this workflow unless overridden and preserves existing functionality for checkout/lint/test operations.

**File to change:** `.github/workflows/ci.yml`  
**Change region:** insert a new top-level `permissions` section between lines 7 and 8 (between trigger config and `jobs:`).  
**No imports, methods, or dependencies are needed.**


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
