### PR TITLE
Improve idle memory efficiency

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,10 @@ ASK_RATE_WINDOW_SECONDS = int(os.environ.get("ASK_RATE_WINDOW_SECONDS", "3600"))
 
 # --- Discord client setup ---
 intents = discord.Intents.default()
-client = discord.Client(intents=intents)
+# max_messages=None disables discord.py's default 1000-message cache. The bot
+# never reads cached messages (quiz state lives in QUIZ_STATE/SQLite and buttons
+# route by custom_id), so the cache is pure idle memory overhead.
+client = discord.Client(intents=intents, max_messages=None)
 tree = app_commands.CommandTree(client)
 
 # --- Anthropic client ---
@@ -110,6 +113,19 @@ try:
         ACC_DOCUMENT_TEXT = _fh.read()
 except FileNotFoundError:
     ACC_DOCUMENT_TEXT = ""
+
+# The cached system prefix, built once at startup. ask_assistant reuses this
+# same list on every request rather than rebuilding the f"ACC documentation:..."
+# string (a ~180KB copy of the whole document) per call. The SDK serializes but
+# never mutates it, and the contents are static, so sharing is safe.
+ACC_SYSTEM_BLOCKS = [
+    {"type": "text", "text": ACC_INSTRUCTIONS},
+    {
+        "type": "text",
+        "text": f"ACC documentation:\n\n{ACC_DOCUMENT_TEXT}",
+        "cache_control": {"type": "ephemeral"},
+    },
+]
 
 
 # --- Button Classes for Quiz Interaction ---
@@ -354,6 +370,17 @@ def rate_limit_ask(user_id: int, now: Optional[datetime] = None) -> Optional[int
         return max(1, int(retry_after.total_seconds()) + 1)
     history.append(now)
     ASK_HISTORY[user_id] = history
+    # Opportunistically drop other users whose entire history has aged out of
+    # the window. Without this, ASK_HISTORY keeps one (eventually empty) list
+    # per distinct user ever seen and grows unbounded while the bot is idle;
+    # pruning here bounds it to users active within the window. /ask is itself
+    # rate-limited so this sweep over a small dict runs rarely and cheaply.
+    stale = [
+        uid for uid, ts in ASK_HISTORY.items()
+        if not ts or ts[-1] <= window_start
+    ]
+    for uid in stale:
+        del ASK_HISTORY[uid]
     return None
 
 
@@ -401,14 +428,9 @@ async def ask_assistant(
         # largest, static block), so the whole prefix is written once and
         # served from cache thereafter. The varying user question lands in
         # `messages`, after the breakpoint, so it never invalidates the cache.
-        "system": [
-            {"type": "text", "text": ACC_INSTRUCTIONS},
-            {
-                "type": "text",
-                "text": f"ACC documentation:\n\n{ACC_DOCUMENT_TEXT}",
-                "cache_control": {"type": "ephemeral"},
-            },
-        ],
+        # Built once at module load (ACC_SYSTEM_BLOCKS) to avoid re-allocating
+        # the ~180KB document string on every request.
+        "system": ACC_SYSTEM_BLOCKS,
         "messages": [{"role": "user", "content": user_msg}],
     }
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -49,3 +49,28 @@ def test_disabled_when_limit_zero(monkeypatch):
     monkeypatch.setattr(app, "ASK_RATE_LIMIT", 0)
     for _ in range(100):
         assert app.rate_limit_ask(1) is None
+
+
+def test_idle_users_are_pruned_from_history():
+    """A user who asked once and went idle is dropped once their history ages
+    out, so ASK_HISTORY tracks only window-active users rather than growing
+    unbounded with every distinct user ever seen."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    # An idle user asks once at base.
+    app.rate_limit_ask(1, now=base)
+    assert 1 in app.ASK_HISTORY
+    # An hour-plus later a different user asks; user 1's history has aged out
+    # of the window, so the sweep removes it.
+    app.rate_limit_ask(2, now=base + timedelta(hours=1, seconds=1))
+    assert 1 not in app.ASK_HISTORY
+    assert 2 in app.ASK_HISTORY
+
+
+def test_active_users_are_not_pruned():
+    """Users with an in-window request survive the sweep."""
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    app.rate_limit_ask(1, now=base)
+    # User 2 asks 30 minutes later — user 1 is still within the window.
+    app.rate_limit_ask(2, now=base + timedelta(minutes=30))
+    assert 1 in app.ASK_HISTORY
+    assert 2 in app.ASK_HISTORY


### PR DESCRIPTION
## Summary

Three low-risk changes that reduce memory the bot holds at idle (and some churn under load), found while reviewing for memory efficiency.

### 1. Disable discord.py's message cache (idle win)
`discord.Client` defaults to `max_messages=1000`, retaining up to 1000 full `Message` objects permanently. This bot never reads cached messages — quiz state lives in `QUIZ_STATE`/SQLite and buttons route by `custom_id` — so the cache was pure idle overhead. Now constructed with `max_messages=None`.

### 2. Prune `ASK_HISTORY` of idle users (idle leak fix)
Previously a user's rate-limit timestamp list was only pruned when *that same user* called `/ask` again, so the dict kept one (eventually empty) entry per distinct user ever seen and grew unbounded while idle. `rate_limit_ask` now sweeps out users whose entire history has aged out of the window, bounding the dict to window-active users. Added tests covering the prune and the no-prune-of-active-users cases.

### 3. Build the cached system prompt once (churn reduction)
`ask_assistant` rebuilt the `system` list — including `f"ACC documentation:\n\n{ACC_DOCUMENT_TEXT}"`, a ~180KB copy of the whole document — on every request. The static blocks are now precomputed once at startup (`ACC_SYSTEM_BLOCKS`) and reused, keeping a single copy of the document string instead of one per call. Caching behavior is unchanged (same blocks, same `cache_control` breakpoint).

## Testing
- `ruff check .` — clean
- `pytest` — 120 passed (2 new)

https://claude.ai/code/session_01Vr3XJPmiYPLkvFGPcfMCZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr3XJPmiYPLkvFGPcfMCZj)_